### PR TITLE
Fix: no need to notify cache expiration in getItem function when skipTTLExtension is true

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -86,14 +86,16 @@ func (cache *Cache) getItem(key string) (*item, bool, bool) {
 		return nil, false, false
 	}
 
+	if cache.skipTTLExtension {
+		return item, true, false
+	}
+
 	if item.ttl >= 0 && (item.ttl > 0 || cache.ttl > 0) {
 		if cache.ttl > 0 && item.ttl == 0 {
 			item.ttl = cache.ttl
 		}
 
-		if !cache.skipTTLExtension {
-			item.touch()
-		}
+		item.touch()
 		cache.priorityQueue.update(item)
 	}
 


### PR DESCRIPTION
There is no need to notify the cache to change expiration when just get item and doesn't extend TTL, because of the priorityQueue will not changed.