### PR TITLE
Fix: notify expiration only if the latest expire time is changed when getItem or SetWithTTL

### DIFF
--- a/priority_queue.go
+++ b/priority_queue.go
@@ -14,6 +14,18 @@ type priorityQueue struct {
 	items []*item
 }
 
+func (pq *priorityQueue) isEmpty() bool {
+	return len(pq.items) == 0
+}
+
+func (pq *priorityQueue) root() *item {
+	if len(pq.items) == 0 {
+		return nil
+	}
+
+	return pq.items[0]
+}
+
 func (pq *priorityQueue) update(item *item) {
 	heap.Fix(pq, item.queueIndex)
 }


### PR DESCRIPTION
If the latest expire time is changed, no need to notify expiration.

# Benchmark Result
|BenchmarkName|Before|After|
|--|--|--|
|BenchmarkCacheSetWithoutTTL-8|1140 ns/op|297.1 ns/op|
|BenchmarkCacheSetWithGlobalTTL-8|1508 ns/op|772.2 ns/op|
|BenchmarkCacheSetWithTTL-8   |1648 ns/op|    808.6 ns/op|

According the benchmark result, it has 2~3 times performance improvement