### PR TITLE
feat(disable_overwrite_on_set): Add ability to disable overwrites when setting an item in the cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -132,6 +132,10 @@ func (c *Cache[K, V]) set(key K, value V, ttl time.Duration) *Item[K, V] {
 	}
 
 	elem := c.get(key, false)
+	// return existing item if overwrite is disabled
+	if elem != nil && c.options.disableOverwriteOnSet {
+		return elem.Value.(*Item[K, V])
+	}
 	if elem != nil {
 		// update/overwrite an existing item
 		item := elem.Value.(*Item[K, V])

--- a/cache_test.go
+++ b/cache_test.go
@@ -444,6 +444,18 @@ func Test_Cache_Set(t *testing.T) {
 	assert.Same(t, item, cache.items.values["test1"].Value)
 }
 
+func Test_Cache_Set_disableOverwriteOnSet(t *testing.T) {
+	cache := prepCache(time.Hour, "test1", "test2", "test3")
+	cache.options.disableOverwriteOnSet = true
+	item := cache.Set("hello", "value123", time.Minute)
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["hello"].Value)
+
+	item2 := cache.Set("hello", "value345", time.Minute)
+	require.NotNil(t, item2)
+	assert.Same(t, item2, cache.items.values["hello"].Value)
+}
+
 func Test_Cache_Get(t *testing.T) {
 	const notFoundKey, foundKey = "notfound", "test1"
 	cc := map[string]struct {

--- a/options.go
+++ b/options.go
@@ -17,10 +17,11 @@ func (fn optionFunc[K, V]) apply(opts *options[K, V]) {
 
 // options holds all available cache configuration options.
 type options[K comparable, V any] struct {
-	capacity          uint64
-	ttl               time.Duration
-	loader            Loader[K, V]
-	disableTouchOnHit bool
+	capacity              uint64
+	ttl                   time.Duration
+	loader                Loader[K, V]
+	disableTouchOnHit     bool
+	disableOverwriteOnSet bool
 }
 
 // applyOptions applies the provided option values to the option struct.
@@ -63,5 +64,16 @@ func WithLoader[K comparable, V any](l Loader[K, V]) Option[K, V] {
 func WithDisableTouchOnHit[K comparable, V any]() Option[K, V] {
 	return optionFunc[K, V](func(opts *options[K, V]) {
 		opts.disableTouchOnHit = true
+	})
+}
+
+// WithDisableOverwriteOnSet prevents the cache instance from
+// overwriting an item when setting the value. This effectively makes
+// the cache a first-insert wins
+// When passing into Get(), it overrides the default value of the
+// cache.
+func WithDisableOverwriteOnSet[K comparable, V any]() Option[K, V] {
+	return optionFunc[K, V](func(opts *options[K, V]) {
+		opts.disableOverwriteOnSet = true
 	})
 }

--- a/options_test.go
+++ b/options_test.go
@@ -58,3 +58,10 @@ func Test_WithDisableTouchOnHit(t *testing.T) {
 	WithDisableTouchOnHit[string, string]().apply(&opts)
 	assert.True(t, opts.disableTouchOnHit)
 }
+
+func Test_WithDisableOverwriteOnSet(t *testing.T) {
+	var opts options[string, string]
+
+	WithDisableOverwriteOnSet[string, string]().apply(&opts)
+	assert.True(t, opts.disableOverwriteOnSet)
+}


### PR DESCRIPTION
Add ability to disable overwrites when setting an item in the cache
- Added new option & associated test
- Added functionality in `cache.set()` to return the item if overwrite is disabled. Could be done as an else.. but wanted to make explicit up front at top of func.

Not sure if more tests need additional testing. I didn't a chance to review all existing cases / structure of testing framework

Addresses issue / enhancement request https://github.com/jellydator/ttlcache/issues/78 