### PR TITLE
Added support of clock package

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -205,17 +205,15 @@ func (cache *Cache) evictjob(reason EvictionReason) {
 
 func (cache *Cache) cleanjob() {
 	// index will only be advanced if the current entry will not be evicted
-	i := 0
-	for item := cache.priorityQueue.items[i]; item.expired(); item = cache.priorityQueue.items[i] {
-
+	for {
+		item := cache.priorityQueue.items[0]
+		if !item.expired() {
+			return
+		}
 		if cache.checkExpireCallback != nil {
 			if !cache.checkExpireCallback(item.key, item.data) {
 				item.touch()
 				cache.priorityQueue.update(item)
-				i++
-				if i == cache.priorityQueue.Len() {
-					break
-				}
 				continue
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/jellydator/ttlcache/v2
 go 1.15
 
 require (
+	github.com/LopatkinEvgeniy/clock v0.0.0-20181129135056-768e3044b657 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/goleak v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/LopatkinEvgeniy/clock v0.0.0-20181129135056-768e3044b657 h1:evAYw3/1eRec+0iucsvGvhxqNa5jE0aEnUXpfaNu0Jg=
+github.com/LopatkinEvgeniy/clock v0.0.0-20181129135056-768e3044b657/go.mod h1:cl4Bu8KP+Cf8kJx2iIv5RBGSYJJ++IFoSUb5VF3VmMo=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/item.go
+++ b/item.go
@@ -2,6 +2,8 @@ package ttlcache
 
 import (
 	"time"
+
+	"github.com/LopatkinEvgeniy/clock"
 )
 
 const (
@@ -11,11 +13,12 @@ const (
 	ItemExpireWithGlobalTTL time.Duration = 0
 )
 
-func newItem(key string, data interface{}, ttl time.Duration) *item {
+func newItem(key string, data interface{}, ttl time.Duration, c clock.Clock) *item {
 	item := &item{
-		data: data,
-		ttl:  ttl,
-		key:  key,
+		data:  data,
+		ttl:   ttl,
+		key:   key,
+		clock: c,
 	}
 	// since nobody is aware yet of this item, it's safe to touch without lock here
 	item.touch()
@@ -28,12 +31,13 @@ type item struct {
 	ttl        time.Duration
 	expireAt   time.Time
 	queueIndex int
+	clock      clock.Clock
 }
 
 // Reset the item expiration time
 func (item *item) touch() {
 	if item.ttl > 0 {
-		item.expireAt = time.Now().Add(item.ttl)
+		item.expireAt = item.clock.Now().Add(item.ttl)
 	}
 }
 

--- a/item.go
+++ b/item.go
@@ -46,5 +46,5 @@ func (item *item) expired() bool {
 	if item.ttl <= 0 {
 		return false
 	}
-	return item.expireAt.Before(time.Now())
+	return item.expireAt.Before(item.clock.Now())
 }

--- a/item_test.go
+++ b/item_test.go
@@ -4,31 +4,35 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LopatkinEvgeniy/clock"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestItemExpired(t *testing.T) {
-	item := newItem("key", "value", (time.Duration(100) * time.Millisecond))
+	mockClock := clock.NewFakeClock()
+	item := newItem("key", "value", (100 * time.Millisecond), mockClock)
 	assert.Equal(t, item.expired(), false, "Expected item to not be expired")
-	<-time.After(200 * time.Millisecond)
+	mockClock.Advance(200 * time.Millisecond)
 	assert.Equal(t, item.expired(), true, "Expected item to be expired once time has passed")
 }
 
 func TestItemTouch(t *testing.T) {
-	item := newItem("key", "value", (time.Duration(100) * time.Millisecond))
+	mockClock := clock.NewFakeClock()
+	item := newItem("key", "value", (100 * time.Millisecond), mockClock)
 	oldExpireAt := item.expireAt
-	<-time.After(50 * time.Millisecond)
+	mockClock.Advance(50 * time.Millisecond)
 	item.touch()
 	assert.NotEqual(t, oldExpireAt, item.expireAt, "Expected dates to be different")
-	<-time.After(150 * time.Millisecond)
+	mockClock.Advance(150 * time.Millisecond)
 	assert.Equal(t, item.expired(), true, "Expected item to be expired")
 	item.touch()
-	<-time.After(50 * time.Millisecond)
+	mockClock.Advance(50 * time.Millisecond)
 	assert.Equal(t, item.expired(), false, "Expected item to not be expired")
 }
 
 func TestItemWithoutExpiration(t *testing.T) {
-	item := newItem("key", "value", ItemNotExpire)
-	<-time.After(50 * time.Millisecond)
+	mockClock := clock.NewFakeClock()
+	item := newItem("key", "value", ItemNotExpire, mockClock)
+	mockClock.Advance(50 * time.Millisecond)
 	assert.Equal(t, item.expired(), false, "Expected item to not be expired")
 }

--- a/priority_queue_test.go
+++ b/priority_queue_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LopatkinEvgeniy/clock"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPriorityQueuePush(t *testing.T) {
 	queue := newPriorityQueue()
 	for i := 0; i < 10; i++ {
-		queue.push(newItem(fmt.Sprintf("key_%d", i), "data", -1))
+		queue.push(newItem(fmt.Sprintf("key_%d", i), "data", -1, clock.NewRealClock()))
 	}
 	assert.Equal(t, queue.Len(), 10, "Expected queue to have 10 elements")
 }
@@ -19,7 +20,7 @@ func TestPriorityQueuePush(t *testing.T) {
 func TestPriorityQueuePop(t *testing.T) {
 	queue := newPriorityQueue()
 	for i := 0; i < 10; i++ {
-		queue.push(newItem(fmt.Sprintf("key_%d", i), "data", -1))
+		queue.push(newItem(fmt.Sprintf("key_%d", i), "data", -1, clock.NewRealClock()))
 	}
 	for i := 0; i < 5; i++ {
 		item := queue.pop()
@@ -39,7 +40,7 @@ func TestPriorityQueuePop(t *testing.T) {
 func TestPriorityQueueCheckOrder(t *testing.T) {
 	queue := newPriorityQueue()
 	for i := 10; i > 0; i-- {
-		queue.push(newItem(fmt.Sprintf("key_%d", i), "data", time.Duration(i)*time.Second))
+		queue.push(newItem(fmt.Sprintf("key_%d", i), "data", time.Duration(i)*time.Second, clock.NewRealClock()))
 	}
 	for i := 1; i <= 10; i++ {
 		item := queue.pop()
@@ -53,7 +54,7 @@ func TestPriorityQueueRemove(t *testing.T) {
 	var itemRemove *item
 	for i := 0; i < 5; i++ {
 		key := fmt.Sprintf("key_%d", i)
-		items[key] = newItem(key, "data", time.Duration(i)*time.Second)
+		items[key] = newItem(key, "data", time.Duration(i)*time.Second, clock.NewRealClock())
 		queue.push(items[key])
 
 		if i == 2 {
@@ -77,7 +78,7 @@ func TestPriorityQueueRemove(t *testing.T) {
 
 func TestPriorityQueueUpdate(t *testing.T) {
 	queue := newPriorityQueue()
-	item := newItem("key", "data", 1*time.Second)
+	item := newItem("key", "data", 1*time.Second, clock.NewRealClock())
 	queue.push(item)
 	assert.Equal(t, queue.Len(), 1, "The queue is supposed to be with 1 item")
 


### PR DESCRIPTION
Clock package allows us to mock time and control it in the way we need to.
It opens the way for more accurate tests, not affected by the real time.