### PR TITLE
add supressed loader initialization function

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -543,6 +543,18 @@ type SuppressedLoader[K comparable, V any] struct {
 	group *singleflight.Group
 }
 
+// NewSuppressedLoader creates a new instance of supressed loader.
+func NewSuppressedLoader[K comparable, V any](loader Loader[K, V], group *singleflight.Group) *SuppressedLoader[K, V] {
+	if group == nil {
+		group = &singleflight.Group{}
+	}
+
+	return &SuppressedLoader[K, V]{
+		Loader: loader,
+		group:  group,
+	}
+}
+
 // Load executes a custom item retrieval logic and returns the item that
 // is associated with the key.
 // It returns nil if the item is not found/valid.

--- a/cache.go
+++ b/cache.go
@@ -538,19 +538,18 @@ func (l LoaderFunc[K, V]) Load(c *Cache[K, V], key K) *Item[K, V] {
 // SuppressedLoader wraps another Loader and suppresses duplicate
 // calls to its Load method.
 type SuppressedLoader[K comparable, V any] struct {
-	Loader[K, V]
-
-	group *singleflight.Group
+	loader Loader[K, V]
+	group  *singleflight.Group
 }
 
-// NewSuppressedLoader creates a new instance of supressed loader.
+// NewSuppressedLoader creates a new instance of suppressed loader.
 func NewSuppressedLoader[K comparable, V any](loader Loader[K, V], group *singleflight.Group) *SuppressedLoader[K, V] {
 	if group == nil {
 		group = &singleflight.Group{}
 	}
 
 	return &SuppressedLoader[K, V]{
-		Loader: loader,
+		loader: loader,
 		group:  group,
 	}
 }
@@ -571,7 +570,7 @@ func (l *SuppressedLoader[K, V]) Load(c *Cache[K, V], key K) *Item[K, V] {
 	// the error that we return ourselves in the func below, which
 	// is also nil
 	res, _, _ := l.group.Do(strKey, func() (interface{}, error) {
-		item := l.Loader.Load(c, key)
+		item := l.loader.Load(c, key)
 		if item == nil {
 			return nil, nil
 		}

--- a/cache.go
+++ b/cache.go
@@ -543,6 +543,8 @@ type SuppressedLoader[K comparable, V any] struct {
 }
 
 // NewSuppressedLoader creates a new instance of suppressed loader.
+// If the group parameter is nil, a newly created instance of
+// *singleflight.Group is used.
 func NewSuppressedLoader[K comparable, V any](loader Loader[K, V], group *singleflight.Group) *SuppressedLoader[K, V] {
 	if group == nil {
 		group = &singleflight.Group{}

--- a/cache_test.go
+++ b/cache_test.go
@@ -965,8 +965,8 @@ func Test_NewSuppressedLoader(t *testing.T) {
 	assert.True(t, called)
 	assert.Equal(t, group, sl.group)
 
-	// uses the provided loader and automatically creates a singleflight
-	// group as nil is passed
+	// uses the provided loader and automatically creates a new instance
+	// of *singleflight.Group as nil parameter is passed
 	called = false
 
 	sl = NewSuppressedLoader[string, string](loader, nil)

--- a/cache_test.go
+++ b/cache_test.go
@@ -945,6 +945,40 @@ func Test_LoaderFunc_Load(t *testing.T) {
 	assert.True(t, called)
 }
 
+func Test_NewSuppressedLoader(t *testing.T) {
+	var called bool
+
+	loader := LoaderFunc[string, string](func(_ *Cache[string, string], _ string) *Item[string, string] {
+		called = true
+		return nil
+	})
+
+	// uses the provided loader and group parameters
+	group := &singleflight.Group{}
+
+	sl := NewSuppressedLoader[string, string](loader, group)
+	require.NotNil(t, sl)
+	require.NotNil(t, sl.Loader)
+
+	sl.Loader.Load(nil, "")
+
+	assert.True(t, called)
+	assert.Equal(t, group, sl.group)
+
+	// uses the provided loader and automatically creates a singleflight
+	// group as nil is passed
+	called = false
+
+	sl = NewSuppressedLoader[string, string](loader, nil)
+	require.NotNil(t, sl)
+	require.NotNil(t, sl.Loader)
+
+	sl.Loader.Load(nil, "")
+
+	assert.True(t, called)
+	assert.NotNil(t, group, sl.group)
+}
+
 func Test_SuppressedLoader_Load(t *testing.T) {
 	var (
 		mu        sync.Mutex

--- a/cache_test.go
+++ b/cache_test.go
@@ -958,9 +958,9 @@ func Test_NewSuppressedLoader(t *testing.T) {
 
 	sl := NewSuppressedLoader[string, string](loader, group)
 	require.NotNil(t, sl)
-	require.NotNil(t, sl.Loader)
+	require.NotNil(t, sl.loader)
 
-	sl.Loader.Load(nil, "")
+	sl.loader.Load(nil, "")
 
 	assert.True(t, called)
 	assert.Equal(t, group, sl.group)
@@ -971,9 +971,9 @@ func Test_NewSuppressedLoader(t *testing.T) {
 
 	sl = NewSuppressedLoader[string, string](loader, nil)
 	require.NotNil(t, sl)
-	require.NotNil(t, sl.Loader)
+	require.NotNil(t, sl.loader)
 
-	sl.Loader.Load(nil, "")
+	sl.loader.Load(nil, "")
 
 	assert.True(t, called)
 	assert.NotNil(t, group, sl.group)
@@ -988,7 +988,7 @@ func Test_SuppressedLoader_Load(t *testing.T) {
 	)
 
 	l := SuppressedLoader[string, string]{
-		Loader: LoaderFunc[string, string](func(_ *Cache[string, string], _ string) *Item[string, string] {
+		loader: LoaderFunc[string, string](func(_ *Cache[string, string], _ string) *Item[string, string] {
 			mu.Lock()
 			loadCalls++
 			mu.Unlock()


### PR DESCRIPTION
Currently there is no way to use the suppressed loader, as the `group` attribute is always `nil` (issue #86). This adds a new function which initializes the structure with the `Loader` and `group` parameters, if the group parameter is `nil`, it creates a new single flight group object.

Closes #86 