### PR TITLE
feat(cache): add LoadOrStore/LoadAndDelete equivalent functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ func main() {
 	cache.Delete("second")
 	cache.DeleteExpired()
 	cache.DeleteAll()
+
+	// retrieve data if in cache otherwise insert data
+	item, retrieved := cache.GetOrSet("fourth", "value4", WithTTL[string, string](ttlcache.DefaultTTL))
+
+	// retrieve and delete data
+	item, present := cache.GetAndDelete("fourth")
 }
 ```
 


### PR DESCRIPTION
related #81

Add similar functions to syncmaps [LoadAndDelete](https://pkg.go.dev/sync#Map.LoadAndDelete) and [LoadOrStore](https://pkg.go.dev/sync#Map.LoadOrStore)