### PR TITLE
use atomics for metrics

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -730,9 +731,7 @@ func Test_Cache_Start(t *testing.T) {
 		go func() {
 			assert.Equal(t, EvictionReasonExpired, r)
 
-			cache.metricsMu.RLock()
-			v := cache.metrics.Evictions
-			cache.metricsMu.RUnlock()
+			v := atomic.LoadUint64(&cache.metrics.Evictions)
 
 			switch v {
 			case 1:


### PR DESCRIPTION
AFAIK metricsMu is not really performing any useful function over and above the likely more efficient atomic integer operations available on most modern CPUs. In the Metric() return function, the metricsMu served to ensure all the counters are returned as of an instant in time when no other counter is incremented relative to other counters, but since the write locks are only held for the duration of an increment of a single element of the structure, even that has no utility (i.e., there are never increments of two counters at once while holding the lock across both increments, which is the only thing the read lock would protect). Finally, the atomic loads probably collapse to simple reads on many CPUs, with the atomic load possibly only forcing cpu cache coherency (i.e., you can probably just write Metrics(){return c.metrics} and be just fine).