### PR TITLE
docs: fixed signature of function argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TTLCache - an in-memory cache with item expiration
+[#](#) TTLCache - an in-memory cache with item expiration
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/jellydator/ttlcache/v3.svg)](https://pkg.go.dev/github.com/jellydator/ttlcache/v3)
 [![Build Status](https://github.com/jellydator/ttlcache/actions/workflows/go.yml/badge.svg)](https://github.com/jellydator/ttlcache/actions/workflows/go.yml)
@@ -100,10 +100,10 @@ func main() {
 		ttlcache.WithCapacity[string, string](300),
 	)
 
-	cache.OnInsertion(func(context.Context, item *ttlcache.Item[string, string]) {
+	cache.OnInsertion(func(ctx context.Context, item *ttlcache.Item[string, string]) {
 		fmt.Println(item.Value(), item.ExpiresAt())
 	})
-	cache.OnEviction(func(context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, string]) {
+	cache.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, string]) {
 		if reason == ttlcache.EvictionReasonCapacityReached {
 			fmt.Println(item.Key(), item.Value())
 		}

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ func main() {
 		ttlcache.WithCapacity[string, string](300),
 	)
 
-	cache.OnInsertion(func(item *ttlcache.Item[string, string]) {
+	cache.OnInsertion(func(context.Context, item *ttlcache.Item[string, string]) {
 		fmt.Println(item.Value(), item.ExpiresAt())
 	})
-	cache.OnEviction(func(reason ttlcache.EvictionReason, item *ttlcache.Item[string, string]) {
+	cache.OnEviction(func(context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, string]) {
 		if reason == ttlcache.EvictionReasonCapacityReached {
 			fmt.Println(item.Key(), item.Value())
 		}


### PR DESCRIPTION
The function passed to `ttlcache.OnInsertion` and `ttlcache.OnEviction` requires `context.Context` as the first argument after commit https://github.com/jellydator/ttlcache/commit/5b5ae2bb953b3dfc15154dd31946dd42957d9a69

I updated the examples accordingly.