### PR TITLE
Added GetOrSetFunc

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -25,3 +25,59 @@ func BenchmarkCacheSetWithGlobalTTL(b *testing.B) {
 		cache.Set(fmt.Sprint(n%1000000), "value", ttlcache.DefaultTTL)
 	}
 }
+
+func BenchmarkCacheGetOrSet(b *testing.B) {
+	const (
+		key = "key"
+	)
+
+	b.Run("Item Present", func(b *testing.B) {
+		b.Run("With GetOrSet", func(b *testing.B) {
+			cache := ttlcache.New[string, []string](
+				ttlcache.WithTTL[string, []string](10 * time.Second),
+			)
+			cache.Set(key, []string{"1", "2"}, ttlcache.DefaultTTL)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				cache.GetOrSet(key, make([]string, 0, 100))
+			}
+		})
+		b.Run("With GetOrSetFunc", func(b *testing.B) {
+			cache := ttlcache.New[string, []string](
+				ttlcache.WithTTL[string, []string](10 * time.Second),
+			)
+			cache.Set(key, []string{"1", "2"}, ttlcache.DefaultTTL)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				cache.GetOrSetFunc(key, func() []string { return make([]string, 0, 100) })
+			}
+		})
+	})
+
+	b.Run("Item Missing", func(b *testing.B) {
+		b.Run("With GetOrSet", func(b *testing.B) {
+			cache := ttlcache.New[int, []string](
+				ttlcache.WithTTL[int, []string](10 * time.Second),
+			)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				cache.GetOrSet(n, make([]string, 0, 100))
+			}
+		})
+		b.Run("With GetOrSetFunc", func(b *testing.B) {
+			cache := ttlcache.New[int, []string](
+				ttlcache.WithTTL[int, []string](10 * time.Second),
+			)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				cache.GetOrSetFunc(n, func() []string {
+					return make([]string, 0, 100)
+				})
+			}
+		})
+	})
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -655,6 +655,30 @@ func Test_Cache_GetOrSet(t *testing.T) {
 	assert.False(t, retrieved)
 }
 
+func Test_Cache_GetOrSetFunc(t *testing.T) {
+	cache := prepCache(time.Hour)
+	item, retrieved := cache.GetOrSetFunc("test", func() string { return "1" }, WithTTL[string, string](time.Minute))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test"].Value)
+	assert.False(t, retrieved)
+
+	item, retrieved = cache.GetOrSetFunc("test", func() string { return "1" }, WithTTL[string, string](time.Minute))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test"].Value)
+	assert.True(t, retrieved)
+
+	item, retrieved = cache.GetOrSetFunc("test2", func() string { return "1" }, WithTTL[string, string](time.Microsecond))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test2"].Value)
+	assert.False(t, retrieved)
+
+	time.Sleep(time.Millisecond)
+	item, retrieved = cache.GetOrSetFunc("test2", func() string { return "2" }, WithTTL[string, string](time.Minute))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test2"].Value)
+	assert.False(t, retrieved)
+}
+
 func Test_Cache_GetAndDelete(t *testing.T) {
 	cache := prepCache(time.Hour, "test1", "test2", "test3")
 	listItem := cache.items.lru.Front()


### PR DESCRIPTION
Hello,

This PR adds a `GetOrSetFunc` method to the cache. The main motivation for this was to avoid allocations when using the cache to store `slices`.  `GetOrSetFunc` mirrors `GetOrSet`, however takes a `valueFunc` rather than a `value`. This function is only called if the key was not found in the cache, avoiding an unnecessary allocation and executing quicker.

I'm conscious I don't have a corresponding issue for this, so feel free to decline if this isn't something you think should be part of this library. 









