### PR TITLE
Added ModifyOrSetFunc

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	ttlcache "github.com/jellydator/ttlcache/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkCacheSetWithoutTTL(b *testing.B) {
@@ -24,4 +25,46 @@ func BenchmarkCacheSetWithGlobalTTL(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		cache.Set(fmt.Sprint(n%1000000), "value", ttlcache.DefaultTTL)
 	}
+}
+
+func BenchmarkCacheModifyOrSetFunc(b *testing.B) {
+	const (
+		key = "key"
+	)
+
+	b.Run("With ModifyOrSetFunc", func(b *testing.B) {
+		cache := ttlcache.New[string, []int](
+			ttlcache.WithTTL[string, []int](50 * time.Second),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			n := n
+			cache.ModifyOrSetFunc(key, func(value []int) []int {
+				return append(value, n)
+			}, func() []int {
+				return append(make([]int, 0, 100), n)
+			}, ttlcache.DefaultTTL)
+		}
+
+		outcome := cache.Get(key)
+		assert.Equal(b, b.N, len(outcome.Value()))
+	})
+
+	b.Run("Without ModifyOrSetFunc", func(b *testing.B) {
+		cache := ttlcache.New[string, []int](
+			ttlcache.WithTTL[string, []int](50 * time.Second),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			n := n
+			item, found := cache.GetOrSet(key, append(make([]int, 0, 100), n))
+			if found {
+				cache.Set(key, append(item.Value(), n), ttlcache.DefaultTTL)
+			}
+		}
+		outcome := cache.Get(key)
+		assert.Equal(b, b.N, len(outcome.Value()))
+	})
 }


### PR DESCRIPTION
Hello,

This PR adds a `ModifyOrSetFunc` method to the cache. The main motivation for this was to avoid allocations when using the cache to store slices as well as to have an atomic way of creating or updating these slices. `ModifyOrSetFunc` takes two function arguments, one that is called if a key already exists, and it's return value is used to update the key's value. 

The second function is called if the key does not exist, with it's return value being used as the key's value. By using a function for the `Set` value, over simply passing the value in, such as in `GetOrSet`, you avoid any allocations if the key is already present, which when being used with large values such as `make([]int, 0, 10000)`, provides a significant speedup as well as reduced GC load. 

I'm conscious I don't have a corresponding issue for this, so feel free to decline if this isn't something you think should be part of this library. I did see https://github.com/jellydator/ttlcache/issues/72 which feels loosely related. 
