### PR TITLE
Fix update of expired items

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -404,7 +404,7 @@ func Test_Cache_get(t *testing.T) {
 				oldItem.ttl = 0
 			}
 
-			elem := cache.get(c.Key, c.Touch)
+			elem := cache.get(c.Key, c.Touch, false)
 
 			if c.Key == notFoundKey {
 				assert.Nil(t, elem)


### PR DESCRIPTION
Fix #123 

Extends `get` method to return expired items to `set` method in order to avoid second insertion into expiration queue.