### PR TITLE
Fix data race in `Items` method

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -469,9 +469,9 @@ func (c *Cache[K, V]) Items() map[K]*Item[K, V] {
 
 	items := make(map[K]*Item[K, V], len(c.items.values))
 	for k := range c.items.values {
-		item := c.get(k, false, false)
-		if item != nil {
-			items[k] = item.Value.(*Item[K, V])
+		item := c.items.values[k].Value.(*Item[K, V])
+		if item != nil && !item.isExpiredUnsafe() {
+			items[k] = item
 		}
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -468,8 +468,8 @@ func (c *Cache[K, V]) Items() map[K]*Item[K, V] {
 	defer c.items.mu.RUnlock()
 
 	items := make(map[K]*Item[K, V], len(c.items.values))
-	for k := range c.items.values {
-		item := c.items.values[k].Value.(*Item[K, V])
+	for k, elem := range c.items.values {
+		item := elem.Value.(*Item[K, V])
 		if item != nil && !item.isExpiredUnsafe() {
 			items[k] = item
 		}

--- a/cache.go
+++ b/cache.go
@@ -467,7 +467,7 @@ func (c *Cache[K, V]) Items() map[K]*Item[K, V] {
 	c.items.mu.RLock()
 	defer c.items.mu.RUnlock()
 
-	items := make(map[K]*Item[K, V], len(c.items.values))
+	items := make(map[K]*Item[K, V])
 	for k, elem := range c.items.values {
 		item := elem.Value.(*Item[K, V])
 		if item != nil && !item.isExpiredUnsafe() {

--- a/cache_test.go
+++ b/cache_test.go
@@ -837,6 +837,7 @@ func Test_Cache_Keys(t *testing.T) {
 
 func Test_Cache_Items(t *testing.T) {
 	cache := prepCache(time.Hour, "1", "2", "3")
+	addToCache(cache, time.Nanosecond, "4")
 	items := cache.Items()
 	require.Len(t, items, 3)
 


### PR DESCRIPTION
Fix [ Issue #139 ](https://github.com/jellydator/ttlcache/issues/139)

There is no issue when running the same race test.
```sh
go test -race -v -failfast -run TestItems -count=1
=== RUN   TestItems
--- PASS: TestItems (0.00s)
PASS
ok      github.com/jellydator/ttlcache/v3       1.487s
```