### PR TITLE
Optimize `Len` method by counting expired items in expiration queue

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -445,14 +445,45 @@ func (c *Cache[K, V]) Len() int {
 	c.items.mu.RLock()
 	defer c.items.mu.RUnlock()
 
-	size := 0
-	for _, elem := range c.items.values {
-		if !elem.Value.(*Item[K, V]).isExpiredUnsafe() {
-			size++
-		}
+	total := c.items.expQueue.Len()
+	if total == 0 {
+		return 0
 	}
 
-	return size
+	// search the heap-based expQueue by BFS
+	countExpired := func() int {
+		var (
+			q   []int
+			res int
+		)
+
+		item := c.items.expQueue[0].Value.(*Item[K, V])
+		if !item.isExpiredUnsafe() {
+			return res
+		}
+
+		q = append(q, 0)
+		for len(q) > 0 {
+			pop := q[0]
+			q = q[1:]
+			res++
+
+			for i := 1; i <= 2; i++ {
+				idx := 2*pop + i
+				if idx >= total {
+					break
+				}
+
+				item = c.items.expQueue[idx].Value.(*Item[K, V])
+				if item.isExpiredUnsafe() {
+					q = append(q, idx)
+				}
+			}
+		}
+		return res
+	}
+
+	return total - countExpired()
 }
 
 // Keys returns all unexpired keys in the cache.

--- a/cache_test.go
+++ b/cache_test.go
@@ -803,8 +803,17 @@ func Test_Cache_Touch(t *testing.T) {
 }
 
 func Test_Cache_Len(t *testing.T) {
-	cache := prepCache(time.Hour, "1", "2")
-	for i := 3; i < 30; i++ {
+	cache := prepCache(time.Hour)
+	assert.Equal(t, 0, cache.Len())
+
+	addToCache(cache, time.Hour, "1")
+	assert.Equal(t, 1, cache.Len())
+
+	addToCache(cache, time.Nanosecond, "2")
+	assert.Equal(t, 1, cache.Len())
+
+	addToCache(cache, time.Hour, "3")
+	for i := 4; i < 30; i++ {
 		addToCache(cache, time.Nanosecond, fmt.Sprint(i))
 	}
 	assert.Equal(t, 2, cache.Len())

--- a/cache_test.go
+++ b/cache_test.go
@@ -804,7 +804,9 @@ func Test_Cache_Touch(t *testing.T) {
 
 func Test_Cache_Len(t *testing.T) {
 	cache := prepCache(time.Hour, "1", "2")
-	addToCache(cache, time.Nanosecond, "3")
+	for i := 3; i < 30; i++ {
+		addToCache(cache, time.Nanosecond, fmt.Sprint(i))
+	}
 	assert.Equal(t, 2, cache.Len())
 }
 


### PR DESCRIPTION
Currently `Len` method is iterating the values map and check if each item is expired or not. I just realized we can count the expired items by searching the heap-based expiration queue using BFS algorithm, and subtract from the total number. I did the implementation and a simple benchmark test, the modified BFS version can benefit a lot. 

```sh
200 valid items and 50 expired items
BenchmarkCacheLen_Original
BenchmarkCacheLen_Original-16        	   36079	     33211 ns/op
BenchmarkCacheLen_BFS
BenchmarkCacheLen_BFS-16             	  105069	     11184 ns/op
```

I think in most use cases, only a few items are expired, so this can be an optimization in general. Please let me know if any code or test need to be modified in the PR.