### PR TITLE
Export NewItem function

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -153,7 +153,7 @@ func (c *Cache[K, V]) set(key K, value V, ttl time.Duration) *Item[K, V] {
 	}
 
 	// create a new item
-	item := newItem(key, value, ttl, c.options.enableVersionTracking)
+	item := NewItem(key, value, ttl, c.options.enableVersionTracking)
 	elem = c.items.lru.PushFront(item)
 	c.items.values[key] = elem
 	c.updateExpirations(true, elem)

--- a/cache_test.go
+++ b/cache_test.go
@@ -1245,7 +1245,7 @@ func prepCache(ttl time.Duration, keys ...string) *Cache[string, string] {
 
 func addToCache(c *Cache[string, string], ttl time.Duration, keys ...string) {
 	for i, key := range keys {
-		item := newItem(
+		item := NewItem(
 			key,
 			fmt.Sprint("value of", key),
 			ttl+time.Duration(i)*time.Minute,

--- a/item.go
+++ b/item.go
@@ -39,8 +39,8 @@ type Item[K comparable, V any] struct {
 	version    int64
 }
 
-// newItem creates a new cache item.
-func newItem[K comparable, V any](key K, value V, ttl time.Duration, enableVersionTracking bool) *Item[K, V] {
+// NewItem creates a new cache item.
+func NewItem[K comparable, V any](key K, value V, ttl time.Duration, enableVersionTracking bool) *Item[K, V] {
 	item := &Item[K, V]{
 		key:   key,
 		value: value,

--- a/item_test.go
+++ b/item_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_newItem(t *testing.T) {
-	item := newItem("key", 123, time.Hour, false)
+func Test_NewItem(t *testing.T) {
+	item := NewItem("key", 123, time.Hour, false)
 	require.NotNil(t, item)
 	assert.Equal(t, "key", item.key)
 	assert.Equal(t, 123, item.value)


### PR DESCRIPTION
There might be multiple reasons for creating an Item object manually. Now the only way of creating such an object is to add it to the cache, which might not always be ideal.
My use-case is allowing a workaround for loader error handling.

By storing the error in the value it could be inspected by the caller of the get function.

Cached function:
```
type cachedValue struct {
	usefulString string
	Err          error
}
```
Loader:
```
loader := ttlcache.LoaderFunc[string, *cachedValue](
		func(c *ttlcache.Cache[string, *cachedValue], key string) *ttlcache.Item[string, *cachedValue] {
			v, err := SomethingThatCouldFail()
			if err != nil {
				return ttlcache.NewItem(key, cachedValue{"", err}, 0, false)
			}
			return c.Set(key, v, 1*time.Hour)
		})
```
Cache setup:
```
cache := ttlcache.New(
		ttlcache.WithTTL[string, *cachedValue](1*time.Hour),
		ttlcache.WithLoader(loader),
	)
```
Get call:
```
// Get the value from the cache
item := cache.Get("key").Value()
if item.Err != nil {
	//handle error
}
// use item.Value().usefulString
```

I would prefer the loader function returning an error in addition to the error, but that would break the current api contract. 
