### PR TITLE
fix(expiration): don't add nottl items

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -79,6 +79,10 @@ func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
 // Not safe for concurrent use by multiple goroutines without additional
 // locking.
 func (c *Cache[K, V]) updateExpirations(fresh bool, elem *list.Element) {
+	if elem.Value.(*Item[K, V]).ttl == NoTTL {
+		return
+	}
+
 	var oldExpiresAt time.Time
 
 	if !c.items.expQueue.isEmpty() {


### PR DESCRIPTION
There's a ton of performance work that can happen here. The expiration queue dominates my profiles on real-world workloads, but that's because it's not doing a swap and is instead always rewriting the head pointer.

I can try to take this on, if you'll take it upstream.