### PR TITLE
Add GetOrSetFunc method

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -395,6 +395,34 @@ func (c *Cache[K, V]) GetOrSet(key K, value V, opts ...Option[K, V]) (*Item[K, V
 	return item, false
 }
 
+// GetOrSetFunc retrieves an item from the cache by the provided key.
+// If the element is not found, it is created by executing the fn function
+// with the provided options and then returned.
+// The bool return value is true if the item was found, false if created
+// during the execution of the method.
+// If the loader is non-nil (i.e., used as an option or specified when
+// creating the cache instance), its execution is skipped.
+func (c *Cache[K, V]) GetOrSetFunc(key K, fn func() V, opts ...Option[K, V]) (*Item[K, V], bool) {
+	c.items.mu.Lock()
+	defer c.items.mu.Unlock()
+
+	elem := c.getWithOpts(key, false, opts...)
+	if elem != nil {
+		return elem, true
+	}
+
+	setOpts := options[K, V]{
+		ttl: c.options.ttl,
+	}
+	applyOptions(&setOpts, opts...) // used only to update the TTL
+
+	value := fn()
+
+	item := c.set(key, value, setOpts.ttl)
+
+	return item, false
+}
+
 // GetAndDelete retrieves an item from the cache by the provided key and
 // then deletes it.
 // The bool return value is true if the item was found before

--- a/cache.go
+++ b/cache.go
@@ -416,9 +416,7 @@ func (c *Cache[K, V]) GetOrSetFunc(key K, fn func() V, opts ...Option[K, V]) (*I
 	}
 	applyOptions(&setOpts, opts...) // used only to update the TTL
 
-	value := fn()
-
-	item := c.set(key, value, setOpts.ttl)
+	item := c.set(key, fn(), setOpts.ttl)
 
 	return item, false
 }

--- a/cache.go
+++ b/cache.go
@@ -377,22 +377,13 @@ func (c *Cache[K, V]) Has(key K) bool {
 // If the loader is non-nil (i.e., used as an option or specified when
 // creating the cache instance), its execution is skipped.
 func (c *Cache[K, V]) GetOrSet(key K, value V, opts ...Option[K, V]) (*Item[K, V], bool) {
-	c.items.mu.Lock()
-	defer c.items.mu.Unlock()
-
-	elem := c.getWithOpts(key, false, opts...)
-	if elem != nil {
-		return elem, true
-	}
-
-	setOpts := options[K, V]{
-		ttl: c.options.ttl,
-	}
-	setOpts = applyOptions(setOpts, opts...) // used only to update the TTL
-
-	item := c.set(key, value, setOpts.ttl)
-
-	return item, false
+	return c.GetOrSetFunc(
+		key,
+		func() V {
+			return value
+		},
+		opts...,
+	)
 }
 
 // GetOrSetFunc retrieves an item from the cache by the provided key.

--- a/cache.go
+++ b/cache.go
@@ -414,7 +414,7 @@ func (c *Cache[K, V]) GetOrSetFunc(key K, fn func() V, opts ...Option[K, V]) (*I
 	setOpts := options[K, V]{
 		ttl: c.options.ttl,
 	}
-	applyOptions(&setOpts, opts...) // used only to update the TTL
+	applyOptions(setOpts, opts...) // used only to update the TTL
 
 	item := c.set(key, fn(), setOpts.ttl)
 

--- a/cache.go
+++ b/cache.go
@@ -414,7 +414,7 @@ func (c *Cache[K, V]) GetOrSetFunc(key K, fn func() V, opts ...Option[K, V]) (*I
 	setOpts := options[K, V]{
 		ttl: c.options.ttl,
 	}
-	applyOptions(setOpts, opts...) // used only to update the TTL
+	setOpts = applyOptions(setOpts, opts...) // used only to update the TTL
 
 	item := c.set(key, fn(), setOpts.ttl)
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -720,6 +720,38 @@ func Test_Cache_GetOrSet(t *testing.T) {
 	assert.False(t, retrieved)
 }
 
+func Test_Cache_GetOrSetFunc(t *testing.T) {
+	cache := prepCache(0, time.Hour)
+	item, retrieved := cache.GetOrSetFunc("test", func() string {
+		return "1"
+	}, WithTTL[string, string](time.Minute))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test"].Value)
+	assert.False(t, retrieved)
+
+	item, retrieved = cache.GetOrSetFunc("test", func() string {
+		return "1"
+	}, WithTTL[string, string](time.Minute))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test"].Value)
+	assert.True(t, retrieved)
+
+	item, retrieved = cache.GetOrSetFunc("test2", func() string {
+		return "1"
+	}, WithTTL[string, string](time.Microsecond))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test2"].Value)
+	assert.False(t, retrieved)
+
+	time.Sleep(time.Millisecond)
+	item, retrieved = cache.GetOrSetFunc("test2", func() string {
+		return "2"
+	}, WithTTL[string, string](time.Minute))
+	require.NotNil(t, item)
+	assert.Same(t, item, cache.items.values["test2"].Value)
+	assert.False(t, retrieved)
+}
+
 func Test_Cache_GetAndDelete(t *testing.T) {
 	cache := prepCache(0, time.Hour, "test1", "test2", "test3")
 	listItem := cache.items.lru.Front()


### PR DESCRIPTION
For example, the method would be useful in an expression like this: 
```
namedLocks.GetOrSetFunc(name, func()*sync.Mutex{
  return new(sync.Mutex)
})
```