### PR TITLE
Make Cache.Get allocation-free

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -71,7 +71,7 @@ func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
 	c.events.insertion.fns = make(map[uint64]func(*Item[K, V]))
 	c.events.eviction.fns = make(map[uint64]func(EvictionReason, *Item[K, V]))
 
-	applyOptions(&c.options, opts...)
+	c.options = applyOptions(c.options, opts...)
 
 	return c
 }
@@ -233,7 +233,7 @@ func (c *Cache[K, V]) getWithOpts(key K, lockAndLoad bool, opts ...Option[K, V])
 		disableTouchOnHit: c.options.disableTouchOnHit,
 	}
 
-	applyOptions(&getOpts, opts...)
+	getOpts = applyOptions(getOpts, opts...)
 
 	if lockAndLoad {
 		c.items.mu.Lock()
@@ -388,7 +388,7 @@ func (c *Cache[K, V]) GetOrSet(key K, value V, opts ...Option[K, V]) (*Item[K, V
 	setOpts := options[K, V]{
 		ttl: c.options.ttl,
 	}
-	applyOptions(&setOpts, opts...) // used only to update the TTL
+	setOpts = applyOptions(setOpts, opts...) // used only to update the TTL
 
 	item := c.set(key, value, setOpts.ttl)
 
@@ -412,7 +412,7 @@ func (c *Cache[K, V]) GetAndDelete(key K, opts ...Option[K, V]) (*Item[K, V], bo
 		getOpts := options[K, V]{
 			loader: c.options.loader,
 		}
-		applyOptions(&getOpts, opts...) // used only to update the loader
+		getOpts = applyOptions(getOpts, opts...) // used only to update the loader
 
 		if getOpts.loader != nil {
 			item := getOpts.loader.Load(c, key)

--- a/cache_test.go
+++ b/cache_test.go
@@ -637,7 +637,7 @@ func Test_Cache_Get(t *testing.T) {
 			cache.options = c.DefaultOptions
 
 			var res *Item[string, string]
-			assert.Equal(t, c.ExpectedNumberOfAllocations, allocsForSingleRun(func() {
+			assert.Equal(t, c.ExpectedNumberOfAllocations, allocsPerSingleRun(func() {
 				res = cache.Get(c.Key, c.CallOptions...)
 			}))
 
@@ -1309,17 +1309,16 @@ func addToCache(c *Cache[string, string], ttl time.Duration, keys ...string) {
 	}
 }
 
-func allocsForSingleRun(f func()) (numAllocs int) {
+func allocsPerSingleRun(f func()) int {
 	// `testing.AllocsPerRun` "warms up" the function for a single run before
-	// measuring allocations, so we need do nothing on the first run.
-	firstRun := false
-	numAllocs = int(testing.AllocsPerRun(1, func() {
+	// measuring allocations, so we need to do nothing on the first run.
+	var firstRun bool
+
+	return int(testing.AllocsPerRun(1, func() {
 		if !firstRun {
 			firstRun = true
 			return
 		}
-
 		f()
 	}))
-	return
 }

--- a/options_test.go
+++ b/options_test.go
@@ -13,9 +13,10 @@ func Test_optionFunc_apply(t *testing.T) {
 
 	var called bool
 
-	optionFunc[string, string](func(_ *options[string, string]) {
+	optionFunc[string, string](func(opts options[string, string]) options[string, string] {
 		called = true
-	}).apply(nil)
+		return opts
+	}).apply(options[string, string]{})
 	assert.True(t, called)
 }
 
@@ -24,7 +25,7 @@ func Test_applyOptions(t *testing.T) {
 
 	var opts options[string, string]
 
-	applyOptions(&opts,
+	opts = applyOptions(opts,
 		WithCapacity[string, string](12),
 		WithTTL[string, string](time.Hour),
 	)
@@ -38,7 +39,7 @@ func Test_WithCapacity(t *testing.T) {
 
 	var opts options[string, string]
 
-	WithCapacity[string, string](12).apply(&opts)
+	opts = WithCapacity[string, string](12).apply(opts)
 	assert.Equal(t, uint64(12), opts.capacity)
 }
 
@@ -47,7 +48,7 @@ func Test_WithTTL(t *testing.T) {
 
 	var opts options[string, string]
 
-	WithTTL[string, string](time.Hour).apply(&opts)
+	opts = WithTTL[string, string](time.Hour).apply(opts)
 	assert.Equal(t, time.Hour, opts.ttl)
 }
 
@@ -57,13 +58,13 @@ func Test_WithVersion(t *testing.T) {
 	var opts options[string, string]
 	var item Item[string, string]
 
-	WithVersion[string, string](true).apply(&opts)
+	opts = WithVersion[string, string](true).apply(opts)
 	assert.Len(t, opts.itemOpts, 1)
 	opts.itemOpts[0].apply(&item)
 	assert.Equal(t, int64(0), item.version)
 
 	opts.itemOpts = []itemOption[string, string]{}
-	WithVersion[string, string](false).apply(&opts)
+	opts = WithVersion[string, string](false).apply(opts)
 	assert.Len(t, opts.itemOpts, 1)
 	opts.itemOpts[0].apply(&item)
 	assert.Equal(t, int64(-1), item.version)
@@ -77,7 +78,7 @@ func Test_WithLoader(t *testing.T) {
 	l := LoaderFunc[string, string](func(_ *Cache[string, string], _ string) *Item[string, string] {
 		return nil
 	})
-	WithLoader[string, string](l).apply(&opts)
+	opts = WithLoader[string, string](l).apply(opts)
 	assert.NotNil(t, opts.loader)
 }
 
@@ -86,7 +87,7 @@ func Test_WithDisableTouchOnHit(t *testing.T) {
 
 	var opts options[string, string]
 
-	WithDisableTouchOnHit[string, string]().apply(&opts)
+	opts = WithDisableTouchOnHit[string, string]().apply(opts)
 	assert.True(t, opts.disableTouchOnHit)
 }
 
@@ -96,7 +97,7 @@ func Test_WithMaxCost(t *testing.T) {
 	var opts options[string, string]
 	var item Item[string, string]
 
-	WithMaxCost[string, string](1024, func(item *Item[string, string]) uint64 { return 1 }).apply(&opts)
+	opts = WithMaxCost[string, string](1024, func(item *Item[string, string]) uint64 { return 1 }).apply(opts)
 
 	assert.Equal(t, uint64(1024), opts.maxCost)
 	assert.Len(t, opts.itemOpts, 1)


### PR DESCRIPTION
**Changes**

- Changed applyOptions and the Option[K,V] to be non-allocating by avoiding pointers
- Added the Test_Get_DoesNotAllocate to make sure that Get does not allocate (it fails before this commit)

**Why**
We encountered a performance issue when we heavily used the Cache, and narrowed it down to the allocation made by `Cache.Get` as part of the options processing. 

Thank you for the great package!