### PR TITLE
fix Range (and RangeBackwards) mutex usage

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -582,16 +582,14 @@ func (c *Cache[K, V]) RangeBackwards(fn func(item *Item[K, V]) bool) {
 	for item := c.items.lru.Back(); item != c.items.lru.Front().Prev(); item = item.Prev() {
 		i := item.Value.(*Item[K, V])
 		expired := i.isExpiredUnsafe()
-		c.items.mu.RUnlock()
-
+		c.items.mu.RUnlock() // unlock mutex so fn func can access it (if it needs to)
 		if !expired && !fn(i) {
 			return
 		}
-
-		if item.Prev() != nil {
-			c.items.mu.RLock()
-		}
+		c.items.mu.RLock()
 	}
+
+	c.items.mu.RUnlock()
 }
 
 // Metrics returns the metrics of the cache.

--- a/cache.go
+++ b/cache.go
@@ -558,16 +558,14 @@ func (c *Cache[K, V]) Range(fn func(item *Item[K, V]) bool) {
 	for item := c.items.lru.Front(); item != c.items.lru.Back().Next(); item = item.Next() {
 		i := item.Value.(*Item[K, V])
 		expired := i.isExpiredUnsafe()
-		c.items.mu.RUnlock()
-
+		c.items.mu.RUnlock() // unlock mutex so fn func can access it (if it needs to)
 		if !expired && !fn(i) {
 			return
 		}
-
-		if item.Next() != nil {
-			c.items.mu.RLock()
-		}
+		c.items.mu.RLock()
 	}
+
+	c.items.mu.RUnlock()
 }
 
 // RangeBackwards calls fn for each unexpired item in the cache in reverse order.


### PR DESCRIPTION
I think I've ran into some sort deadlocking issue with `ttlcache` cache recently, I haven't been able to pinpoint it exactly yet but upon cursory look at `Range` method it seems to me its usage of mutex isn't 100% correct, 

in particular it seems we might call the `item != c.items.lru.Back().Next(); item = item.Next()` part of `for` loop without `c.items.mu` read-locked - which seems would result into thread-unsafe read (not sure if reading `item.Next()` without mutex held is fine or not but reading `c.items.lru.Back()` probably isn't)

same reasoning applies to `RangeBackwards` I guess - but I haven't changed it yet in this PR (waiting for initial review first)