### PR TITLE
fix: Deadlock during cost calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ func main() {
 
 To restrict the cache's capacity based on criteria beyond the number
 of items it can hold, the `ttlcache.WithMaxCost` option allows for
-implementing custom strategies. The following example demonstrates
-how to limit the maximum memory usage of a cache to 5KiB:
+implementing custom strategies. The following example shows how to limit
+memory usage for cached entries to ~5KiB.
 ```go
 import (
     "github.com/jellydator/ttlcache"
@@ -157,10 +157,9 @@ import (
 func main() {
     cache := ttlcache.New[string, string](
         ttlcache.WithMaxCost[string, string](5120, func(item ttlcache.CostItem[string, string]) uint64 {
-            // The cache maintains internal structures averaging ~144 bytes per entry.
-            // Since this example uses strings for both key and value, and each string
-            // has 16 bytes of metadata, we can estimate the memory used per entry as:
-            return 176 + len(item.Key) + len(item.Value)
+            // Note: The below line doesn't include memory used by internal
+			// structures or string metadata for the key and the value.
+            return len(item.Key) + len(item.Value)
         }), 
     )
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ func main() {
     cache := ttlcache.New[string, string](
         ttlcache.WithMaxCost[string, string](5120, func(item ttlcache.CostItem[string, string]) uint64 {
             // Note: The below line doesn't include memory used by internal
-			// structures or string metadata for the key and the value.
+            // structures or string metadata for the key and the value.
             return len(item.Key) + len(item.Value)
         }), 
     )

--- a/README.md
+++ b/README.md
@@ -142,20 +142,22 @@ func main() {
 }
 ```
 
-To restrict the cache's capacity based on criteria beyond the number
-of items it can hold, the `ttlcache.WithMaxCost` option allows for
-implementing custom strategies. The following example demonstrates
-how to limit the maximum memory usage of a cache to 5KiB:
+To restrict a cache's capacity based on criteria beyond just the number of
+items it holds, the `ttlcache.WithMaxCost` option can be used to implement 
+custom cost-based strategies. The following example demonstrates how to limit
+a cache's maximum memory usage to approximately 5KiB:
 ```go
 import (
     "github.com/jellydator/ttlcache"
-    "github.com/DmitriyVTitov/size"
 )
 
 func main() {
     cache := ttlcache.New[string, string](
-        ttlcache.WithMaxCost[string, string](5120, func(item *ttlcache.Item[string, string]) uint64 {
-            return uint64(size.Of(item))
+        ttlcache.WithMaxCost[string, string](5120, func(item ttlcache.CostItem[string, string]) uint64 {
+            // The cache maintains internal structures averaging ~144 bytes per entry.
+            // Since this example uses strings for both key and value, and each string
+            // has 16 bytes of metadata, we can estimate the memory used per entry as:
+            return 144 + 2*16 + len(item.Key) + len(item.Value)
         }), 
     )
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1305,8 +1305,8 @@ func prepCache(maxCost uint64, ttl time.Duration, keys ...string) *Cache[string,
 	if maxCost != 0 {
 		c.options.maxCost = maxCost
 		c.options.itemOpts = append(c.options.itemOpts,
-			withCostFunc[string, string](func(item *Item[string, string]) uint64 {
-				return uint64(len(item.value))
+			withCostFunc[string, string](func(item CostItem[string, string]) uint64 {
+				return uint64(len(item.Value))
 			}))
 	}
 

--- a/item.go
+++ b/item.go
@@ -39,7 +39,7 @@ type Item[K comparable, V any] struct {
 	version       int64
 	calculateCost CostFunc[K, V]
 	cost          uint64
-	inUpdate      bool
+	isSnapshot    bool
 }
 
 // NewItem creates a new cache item.
@@ -74,26 +74,30 @@ func (item *Item[K, V]) update(value V, ttl time.Duration) {
 
 	item.value = value
 
-	item.inUpdate = true
-	item.cost = item.calculateCost(item)
-	item.inUpdate = false
-
 	// update version if enabled
 	if item.version > -1 {
 		item.version++
 	}
 
 	// no need to update ttl or expiry in this case
-	if ttl == PreviousOrDefaultTTL {
-		return
+	if ttl != PreviousOrDefaultTTL {
+		item.ttl = ttl
+		// reset expiration timestamp because the new TTL may be 0 or below
+		item.expiresAt = time.Time{}
+		item.touchUnsafe()
 	}
 
-	item.ttl = ttl
-
-	// reset expiration timestamp because the new TTL may be
-	// 0 or below
-	item.expiresAt = time.Time{}
-	item.touchUnsafe()
+	// calculating the costs over a snapshot rather the current
+	// item to avoid a deadlock if the implementation of the callback
+	// uses the public getter functions.
+	item.cost = item.calculateCost(&Item[K, V]{
+		key:        item.key,
+		value:      item.value,
+		version:    item.version,
+		ttl:        item.ttl,
+		expiresAt:  item.expiresAt,
+		isSnapshot: true,
+	})
 }
 
 // touch updates the item's expiration timestamp.
@@ -117,10 +121,12 @@ func (item *Item[K, V]) touchUnsafe() {
 // IsExpired returns a bool value that indicates whether the item
 // is expired.
 func (item *Item[K, V]) IsExpired() bool {
-	if !item.inUpdate {
-		item.mu.RLock()
-		defer item.mu.RUnlock()
+	if item.isSnapshot {
+		return item.isExpiredUnsafe()
 	}
+
+	item.mu.RLock()
+	defer item.mu.RUnlock()
 
 	return item.isExpiredUnsafe()
 }
@@ -137,40 +143,48 @@ func (item *Item[K, V]) isExpiredUnsafe() bool {
 
 // Key returns the key of the item.
 func (item *Item[K, V]) Key() K {
-	if !item.inUpdate {
-		item.mu.RLock()
-		defer item.mu.RUnlock()
+	if item.isSnapshot {
+		return item.key
 	}
+
+	item.mu.RLock()
+	defer item.mu.RUnlock()
 
 	return item.key
 }
 
 // Value returns the value of the item.
 func (item *Item[K, V]) Value() V {
-	if !item.inUpdate {
-		item.mu.RLock()
-		defer item.mu.RUnlock()
+	if item.isSnapshot {
+		return item.value
 	}
+
+	item.mu.RLock()
+	defer item.mu.RUnlock()
 
 	return item.value
 }
 
 // TTL returns the TTL value of the item.
 func (item *Item[K, V]) TTL() time.Duration {
-	if !item.inUpdate {
-		item.mu.RLock()
-		defer item.mu.RUnlock()
+	if item.isSnapshot {
+		return item.ttl
 	}
+
+	item.mu.RLock()
+	defer item.mu.RUnlock()
 
 	return item.ttl
 }
 
 // ExpiresAt returns the expiration timestamp of the item.
 func (item *Item[K, V]) ExpiresAt() time.Time {
-	if !item.inUpdate {
-		item.mu.RLock()
-		defer item.mu.RUnlock()
+	if item.isSnapshot {
+		return item.expiresAt
 	}
+
+	item.mu.RLock()
+	defer item.mu.RUnlock()
 
 	return item.expiresAt
 }
@@ -179,10 +193,12 @@ func (item *Item[K, V]) ExpiresAt() time.Time {
 // changes made to the item.
 // If version tracking is disabled, the return value is always -1.
 func (item *Item[K, V]) Version() int64 {
-	if !item.inUpdate {
-		item.mu.RLock()
-		defer item.mu.RUnlock()
+	if item.isSnapshot {
+		return item.version
 	}
+
+	item.mu.RLock()
+	defer item.mu.RUnlock()
 
 	return item.version
 }

--- a/item.go
+++ b/item.go
@@ -18,6 +18,13 @@ const (
 	DefaultTTL time.Duration = 0
 )
 
+// CostItem holds the key and the value of the Item object for
+// Item cost calculation purposes.
+type CostItem[K comparable, V any] struct {
+	Key   K
+	Value V
+}
+
 // Item holds all the information that is associated with a single
 // cache value.
 type Item[K comparable, V any] struct {
@@ -39,7 +46,6 @@ type Item[K comparable, V any] struct {
 	version       int64
 	calculateCost CostFunc[K, V]
 	cost          uint64
-	isSnapshot    bool
 }
 
 // NewItem creates a new cache item.
@@ -54,7 +60,7 @@ func newItemWithOpts[K comparable, V any](key K, value V, ttl time.Duration, opt
 		value:         value,
 		ttl:           ttl,
 		version:       -1,
-		calculateCost: func(item *Item[K, V]) uint64 { return 0 },
+		calculateCost: func(item CostItem[K, V]) uint64 { return 0 },
 	}
 
 	for _, opt := range opts {
@@ -62,7 +68,10 @@ func newItemWithOpts[K comparable, V any](key K, value V, ttl time.Duration, opt
 	}
 
 	item.touch()
-	item.cost = item.calculateCost(item)
+	item.cost = item.calculateCost(CostItem[K, V]{
+		Key:   key,
+		Value: value,
+	})
 
 	return item
 }
@@ -87,16 +96,10 @@ func (item *Item[K, V]) update(value V, ttl time.Duration) {
 		item.touchUnsafe()
 	}
 
-	// calculating the costs over a snapshot rather the current
-	// item to avoid a deadlock if the implementation of the callback
-	// uses the public getter functions.
-	item.cost = item.calculateCost(&Item[K, V]{
-		key:        item.key,
-		value:      item.value,
-		version:    item.version,
-		ttl:        item.ttl,
-		expiresAt:  item.expiresAt,
-		isSnapshot: true,
+	// calculating the costs
+	item.cost = item.calculateCost(CostItem[K, V]{
+		Key:   item.key,
+		Value: item.value,
 	})
 }
 
@@ -121,10 +124,6 @@ func (item *Item[K, V]) touchUnsafe() {
 // IsExpired returns a bool value that indicates whether the item
 // is expired.
 func (item *Item[K, V]) IsExpired() bool {
-	if item.isSnapshot {
-		return item.isExpiredUnsafe()
-	}
-
 	item.mu.RLock()
 	defer item.mu.RUnlock()
 
@@ -143,10 +142,6 @@ func (item *Item[K, V]) isExpiredUnsafe() bool {
 
 // Key returns the key of the item.
 func (item *Item[K, V]) Key() K {
-	if item.isSnapshot {
-		return item.key
-	}
-
 	item.mu.RLock()
 	defer item.mu.RUnlock()
 
@@ -155,10 +150,6 @@ func (item *Item[K, V]) Key() K {
 
 // Value returns the value of the item.
 func (item *Item[K, V]) Value() V {
-	if item.isSnapshot {
-		return item.value
-	}
-
 	item.mu.RLock()
 	defer item.mu.RUnlock()
 
@@ -167,10 +158,6 @@ func (item *Item[K, V]) Value() V {
 
 // TTL returns the TTL value of the item.
 func (item *Item[K, V]) TTL() time.Duration {
-	if item.isSnapshot {
-		return item.ttl
-	}
-
 	item.mu.RLock()
 	defer item.mu.RUnlock()
 
@@ -179,10 +166,6 @@ func (item *Item[K, V]) TTL() time.Duration {
 
 // ExpiresAt returns the expiration timestamp of the item.
 func (item *Item[K, V]) ExpiresAt() time.Time {
-	if item.isSnapshot {
-		return item.expiresAt
-	}
-
 	item.mu.RLock()
 	defer item.mu.RUnlock()
 
@@ -193,10 +176,6 @@ func (item *Item[K, V]) ExpiresAt() time.Time {
 // changes made to the item.
 // If version tracking is disabled, the return value is always -1.
 func (item *Item[K, V]) Version() int64 {
-	if item.isSnapshot {
-		return item.version
-	}
-
 	item.mu.RLock()
 	defer item.mu.RUnlock()
 

--- a/item.go
+++ b/item.go
@@ -39,6 +39,7 @@ type Item[K comparable, V any] struct {
 	version       int64
 	calculateCost CostFunc[K, V]
 	cost          uint64
+	inUpdate      bool
 }
 
 // NewItem creates a new cache item.
@@ -72,7 +73,10 @@ func (item *Item[K, V]) update(value V, ttl time.Duration) {
 	defer item.mu.Unlock()
 
 	item.value = value
+
+	item.inUpdate = true
 	item.cost = item.calculateCost(item)
+	item.inUpdate = false
 
 	// update version if enabled
 	if item.version > -1 {
@@ -113,8 +117,10 @@ func (item *Item[K, V]) touchUnsafe() {
 // IsExpired returns a bool value that indicates whether the item
 // is expired.
 func (item *Item[K, V]) IsExpired() bool {
-	item.mu.RLock()
-	defer item.mu.RUnlock()
+	if !item.inUpdate {
+		item.mu.RLock()
+		defer item.mu.RUnlock()
+	}
 
 	return item.isExpiredUnsafe()
 }
@@ -131,32 +137,40 @@ func (item *Item[K, V]) isExpiredUnsafe() bool {
 
 // Key returns the key of the item.
 func (item *Item[K, V]) Key() K {
-	item.mu.RLock()
-	defer item.mu.RUnlock()
+	if !item.inUpdate {
+		item.mu.RLock()
+		defer item.mu.RUnlock()
+	}
 
 	return item.key
 }
 
 // Value returns the value of the item.
 func (item *Item[K, V]) Value() V {
-	item.mu.RLock()
-	defer item.mu.RUnlock()
+	if !item.inUpdate {
+		item.mu.RLock()
+		defer item.mu.RUnlock()
+	}
 
 	return item.value
 }
 
 // TTL returns the TTL value of the item.
 func (item *Item[K, V]) TTL() time.Duration {
-	item.mu.RLock()
-	defer item.mu.RUnlock()
+	if !item.inUpdate {
+		item.mu.RLock()
+		defer item.mu.RUnlock()
+	}
 
 	return item.ttl
 }
 
 // ExpiresAt returns the expiration timestamp of the item.
 func (item *Item[K, V]) ExpiresAt() time.Time {
-	item.mu.RLock()
-	defer item.mu.RUnlock()
+	if !item.inUpdate {
+		item.mu.RLock()
+		defer item.mu.RUnlock()
+	}
 
 	return item.expiresAt
 }
@@ -165,8 +179,10 @@ func (item *Item[K, V]) ExpiresAt() time.Time {
 // changes made to the item.
 // If version tracking is disabled, the return value is always -1.
 func (item *Item[K, V]) Version() int64 {
-	item.mu.RLock()
-	defer item.mu.RUnlock()
+	if !item.inUpdate {
+		item.mu.RLock()
+		defer item.mu.RUnlock()
+	}
 
 	return item.version
 }

--- a/item_test.go
+++ b/item_test.go
@@ -34,7 +34,7 @@ func Test_newItemWithOpts(t *testing.T) {
 				assert.Equal(t, int64(-1), item.version)
 				assert.Equal(t, uint64(0), item.cost)
 				require.NotNil(t, item.calculateCost)
-				assert.Equal(t, uint64(0), item.calculateCost(item))
+				assert.Equal(t, uint64(0), item.calculateCost(CostItem[string, int]{Key: item.key, Value: item.value}))
 			},
 		},
 		{
@@ -46,7 +46,7 @@ func Test_newItemWithOpts(t *testing.T) {
 				assert.Equal(t, int64(-1), item.version)
 				assert.Equal(t, uint64(0), item.cost)
 				require.NotNil(t, item.calculateCost)
-				assert.Equal(t, uint64(0), item.calculateCost(item))
+				assert.Equal(t, uint64(0), item.calculateCost(CostItem[string, int]{Key: item.key, Value: item.value}))
 			},
 		},
 		{
@@ -58,19 +58,19 @@ func Test_newItemWithOpts(t *testing.T) {
 				assert.Equal(t, int64(0), item.version)
 				assert.Equal(t, uint64(0), item.cost)
 				require.NotNil(t, item.calculateCost)
-				assert.Equal(t, uint64(0), item.calculateCost(item))
+				assert.Equal(t, uint64(0), item.calculateCost(CostItem[string, int]{Key: item.key, Value: item.value}))
 			},
 		},
 		{
 			uc: "item with cost calculation",
 			opts: []itemOption[string, int]{
-				withCostFunc[string, int](func(item *Item[string, int]) uint64 { return 5 }),
+				withCostFunc[string, int](func(item CostItem[string, int]) uint64 { return 5 }),
 			},
 			assert: func(t *testing.T, item *Item[string, int]) {
 				assert.Equal(t, int64(-1), item.version)
 				assert.Equal(t, uint64(5), item.cost)
 				require.NotNil(t, item.calculateCost)
-				assert.Equal(t, uint64(5), item.calculateCost(item))
+				assert.Equal(t, uint64(5), item.calculateCost(CostItem[string, int]{Key: item.key, Value: item.value}))
 			},
 		},
 	} {
@@ -152,7 +152,7 @@ func Test_Item_update(t *testing.T) {
 			uc: "with version calculation and version tracking",
 			opts: []itemOption[string, string]{
 				withVersionTracking[string, string](true),
-				withCostFunc[string, string](func(item *Item[string, string]) uint64 { return uint64(len(item.Value())) }),
+				withCostFunc[string, string](func(item CostItem[string, string]) uint64 { return uint64(len(item.Value)) }),
 			},
 			ttl: time.Hour,
 			assert: func(t *testing.T, item *Item[string, string]) {

--- a/item_test.go
+++ b/item_test.go
@@ -152,7 +152,7 @@ func Test_Item_update(t *testing.T) {
 			uc: "with version calculation and version tracking",
 			opts: []itemOption[string, string]{
 				withVersionTracking[string, string](true),
-				withCostFunc[string, string](func(item *Item[string, string]) uint64 { return uint64(len(item.value)) }),
+				withCostFunc[string, string](func(item *Item[string, string]) uint64 { return uint64(len(item.Value())) }),
 			},
 			ttl: time.Hour,
 			assert: func(t *testing.T, item *Item[string, string]) {

--- a/options.go
+++ b/options.go
@@ -17,7 +17,7 @@ func (fn optionFunc[K, V]) apply(opts options[K, V]) options[K, V] {
 
 // CostFunc is used to calculate the cost of the key and the item to be
 // inserted into the cache.
-type CostFunc[K comparable, V any] func(item *Item[K, V]) uint64
+type CostFunc[K comparable, V any] func(item CostItem[K, V]) uint64
 
 // options holds all available cache configuration options.
 type options[K comparable, V any] struct {

--- a/options_test.go
+++ b/options_test.go
@@ -97,14 +97,14 @@ func Test_WithMaxCost(t *testing.T) {
 	var opts options[string, string]
 	var item Item[string, string]
 
-	opts = WithMaxCost[string, string](1024, func(item *Item[string, string]) uint64 { return 1 }).apply(opts)
+	opts = WithMaxCost[string, string](1024, func(item CostItem[string, string]) uint64 { return 1 }).apply(opts)
 
 	assert.Equal(t, uint64(1024), opts.maxCost)
 	assert.Len(t, opts.itemOpts, 1)
 	opts.itemOpts[0].apply(&item)
 	assert.Equal(t, uint64(0), item.cost)
 	assert.NotNil(t, item.calculateCost)
-	assert.Equal(t, uint64(1), item.calculateCost(&item))
+	assert.Equal(t, uint64(1), item.calculateCost(CostItem[string, string]{Key: item.key, Value: item.value}))
 }
 
 func Test_withVersionTracking(t *testing.T) {
@@ -126,11 +126,11 @@ func Test_withCostFunc(t *testing.T) {
 
 	var item Item[string, string]
 
-	opt := withCostFunc[string, string](func(item *Item[string, string]) uint64 {
+	opt := withCostFunc[string, string](func(item CostItem[string, string]) uint64 {
 		return 10
 	})
 	opt.apply(&item)
 	assert.Equal(t, uint64(0), item.cost)
 	require.NotNil(t, item.calculateCost)
-	assert.Equal(t, uint64(10), item.calculateCost(&item))
+	assert.Equal(t, uint64(10), item.calculateCost(CostItem[string, string]{Key: item.key, Value: item.value}))
 }


### PR DESCRIPTION
Unfortunately, the implementation, I've done in #152 can cause a deadlock during cost calculation:

The `update` method of the `Item` locks an RW lock and calls the `item.calculateCost(item)`, which if configured, may make use of the available getter functions of the item object. All these functions make however use of the R lock - thus we have a deadlock.

This PR updates the implementation of the `Item` and performs the calculation of the item cost on a snapshot rather the actual update.

The test has been updated as well to use a public method. Without the update to the Item implementation the corresponding test will run into a deadlock
