### PR TITLE
Handle empty cache while using Range or RangeBackwards

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -572,7 +572,7 @@ func (c *Cache[K, V]) Range(fn func(item *Item[K, V]) bool) {
 		return
 	}
 
-	for item := c.items.lru.Front(); item != c.items.lru.Back().Next(); item = item.Next() {
+	for item := c.items.lru.Front(); c.items.lru.Len() != 0 && item != c.items.lru.Back().Next(); item = item.Next() {
 		i := item.Value.(*Item[K, V])
 		expired := i.isExpiredUnsafe()
 		c.items.mu.RUnlock() // unlock mutex so fn func can access it (if it needs to)
@@ -596,7 +596,7 @@ func (c *Cache[K, V]) RangeBackwards(fn func(item *Item[K, V]) bool) {
 		return
 	}
 
-	for item := c.items.lru.Back(); item != c.items.lru.Front().Prev(); item = item.Prev() {
+	for item := c.items.lru.Back(); c.items.lru.Len() != 0 && item != c.items.lru.Front().Prev(); item = item.Prev() {
 		i := item.Value.(*Item[K, V])
 		expired := i.isExpiredUnsafe()
 		c.items.mu.RUnlock() // unlock mutex so fn func can access it (if it needs to)

--- a/cache_test.go
+++ b/cache_test.go
@@ -919,10 +919,28 @@ func Test_Cache_Range(t *testing.T) {
 
 	assert.Equal(t, []string{"5", "4"}, results)
 
+	results = nil
+
+	c.Range(func(item *Item[string, string]) bool {
+		results = append(results, item.Key())
+		return true
+	})
+
+	assert.Equal(t, []string{"5", "4", "3", "2", "1"}, results)
+
 	emptyCache := New[string, string]()
 	assert.NotPanics(t, func() {
 		emptyCache.Range(func(item *Item[string, string]) bool {
 			return false
+		})
+	})
+
+	deletedCache := New[string, string]()
+	addToCache(deletedCache, time.Minute, "6", "3", "4")
+	assert.NotPanics(t, func() {
+		deletedCache.Range(func(item *Item[string, string]) bool {
+			deletedCache.DeleteAll()
+			return true
 		})
 	})
 }
@@ -941,10 +959,28 @@ func Test_Cache_RangeBackwards(t *testing.T) {
 
 	assert.Equal(t, []string{"2", "3", "4"}, results)
 
+	results = nil
+
+	c.RangeBackwards(func(item *Item[string, string]) bool {
+		results = append(results, item.Key())
+		return true
+	})
+
+	assert.Equal(t, []string{"2", "3", "4", "5"}, results)
+
 	emptyCache := New[string, string]()
 	assert.NotPanics(t, func() {
 		emptyCache.RangeBackwards(func(item *Item[string, string]) bool {
 			return false
+		})
+	})
+
+	deletedCache := New[string, string]()
+	addToCache(deletedCache, time.Minute, "6", "3", "4")
+	assert.NotPanics(t, func() {
+		deletedCache.RangeBackwards(func(item *Item[string, string]) bool {
+			deletedCache.DeleteAll()
+			return true
 		})
 	})
 }


### PR DESCRIPTION
After adding this snippet:

```go
deletedCache := New[string, string]()
addToCache(deletedCache, time.Minute, "6", "3", "4")
assert.NotPanics(t, func() {
	deletedCache.Range(func(item *Item[string, string]) bool {
		deletedCache.DeleteAll()
		return true
	})
})
```

I received a panic as the check part of the loop assumed that the cache wouldn't be empty. A simple len check fixes this.

Closes #174.