### PR TITLE
Allow subsequent calls to `Start` and `Stop`

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -55,14 +55,18 @@ type Cache[K comparable, V any] struct {
 		}
 	}
 
+	stopMu  sync.RWMutex
 	stopCh  chan struct{}
+	stopped bool
+
 	options options[K, V]
 }
 
 // New creates a new instance of cache.
 func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
 	c := &Cache[K, V]{
-		stopCh: make(chan struct{}),
+		stopCh:  make(chan struct{}),
+		stopped: true, // cache cleanup process is stopped by default
 	}
 	c.items.values = make(map[K]*list.Element)
 	c.items.lru = list.New()
@@ -621,6 +625,15 @@ func (c *Cache[K, V]) Metrics() Metrics {
 // expired items.
 // It blocks until Stop is called.
 func (c *Cache[K, V]) Start() {
+	c.stopMu.Lock()
+	if !c.stopped {
+		c.stopMu.Unlock()
+		return
+	}
+
+	c.stopped = false
+	c.stopMu.Unlock()
+
 	waitDur := func() time.Duration {
 		c.items.mu.RLock()
 		defer c.items.mu.RUnlock()
@@ -659,6 +672,10 @@ func (c *Cache[K, V]) Start() {
 	for {
 		select {
 		case <-c.stopCh:
+			c.stopMu.Lock()
+			c.stopped = true
+			c.stopMu.Unlock()
+
 			return
 		case d := <-c.items.timerCh:
 			stop()
@@ -674,6 +691,13 @@ func (c *Cache[K, V]) Start() {
 // Stop stops the automatic cleanup process.
 // It blocks until the cleanup process exits.
 func (c *Cache[K, V]) Stop() {
+	c.stopMu.RLock()
+	defer c.stopMu.RUnlock()
+
+	if c.stopped {
+		return
+	}
+
 	c.stopCh <- struct{}{}
 }
 

--- a/cache.go
+++ b/cache.go
@@ -55,7 +55,7 @@ type Cache[K comparable, V any] struct {
 		}
 	}
 
-	stopMu  sync.RWMutex
+	stopMu  sync.Mutex
 	stopCh  chan struct{}
 	stopped bool
 
@@ -672,10 +672,6 @@ func (c *Cache[K, V]) Start() {
 	for {
 		select {
 		case <-c.stopCh:
-			c.stopMu.Lock()
-			c.stopped = true
-			c.stopMu.Unlock()
-
 			return
 		case d := <-c.items.timerCh:
 			stop()
@@ -691,14 +687,16 @@ func (c *Cache[K, V]) Start() {
 // Stop stops the automatic cleanup process.
 // It blocks until the cleanup process exits.
 func (c *Cache[K, V]) Stop() {
-	c.stopMu.RLock()
-	defer c.stopMu.RUnlock()
+	c.stopMu.Lock()
+	defer c.stopMu.Unlock()
 
 	if c.stopped {
 		return
 	}
 
 	c.stopCh <- struct{}{}
+	c.stopped = true
+
 }
 
 // OnInsertion adds the provided function to be executed when

--- a/cache_test.go
+++ b/cache_test.go
@@ -1029,7 +1029,6 @@ func Test_Cache_Start(t *testing.T) {
 	cache.events.eviction.fns[1] = fn
 
 	cache.Start()
-	assert.True(t, cache.stopped) // callback fn stops the cache
 
 	cache.events.eviction.fns = make(map[uint64]func(EvictionReason, *Item[string, string]))
 	cache.stopCh = make(chan struct{})
@@ -1038,17 +1037,9 @@ func Test_Cache_Start(t *testing.T) {
 	go cache.Start() // should be no-op
 
 	assert.Eventually(t, func() bool {
-		cache.stopMu.RLock()
-		defer cache.stopMu.RUnlock()
+		cache.stopMu.Lock()
+		defer cache.stopMu.Unlock()
 		return !cache.stopped
-	}, time.Second, time.Millisecond*100)
-
-	close(cache.stopCh)
-
-	assert.Eventually(t, func() bool {
-		cache.stopMu.RLock()
-		defer cache.stopMu.RUnlock()
-		return cache.stopped
 	}, time.Second, time.Millisecond*100)
 
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1029,12 +1029,39 @@ func Test_Cache_Start(t *testing.T) {
 	cache.events.eviction.fns[1] = fn
 
 	cache.Start()
+	assert.True(t, cache.stopped) // callback fn stops the cache
+
+	cache.events.eviction.fns = make(map[uint64]func(EvictionReason, *Item[string, string]))
+	cache.stopCh = make(chan struct{})
+
+	go cache.Start()
+	go cache.Start() // should be no-op
+
+	assert.Eventually(t, func() bool {
+		cache.stopMu.RLock()
+		defer cache.stopMu.RUnlock()
+		return !cache.stopped
+	}, time.Second, time.Millisecond*100)
+
+	close(cache.stopCh)
+
+	assert.Eventually(t, func() bool {
+		cache.stopMu.RLock()
+		defer cache.stopMu.RUnlock()
+		return cache.stopped
+	}, time.Second, time.Millisecond*100)
+
 }
 
 func Test_Cache_Stop(t *testing.T) {
 	cache := Cache[string, string]{
-		stopCh: make(chan struct{}, 1),
+		stopCh:  make(chan struct{}, 1),
+		stopped: true,
 	}
+	cache.Stop()
+	assert.Len(t, cache.stopCh, 0)
+
+	cache.stopped = false
 	cache.Stop()
 	assert.Len(t, cache.stopCh, 1)
 }
@@ -1333,7 +1360,9 @@ func Test_SuppressedLoader_Load(t *testing.T) {
 }
 
 func prepCache(maxCost uint64, ttl time.Duration, keys ...string) *Cache[string, string] {
-	c := &Cache[string, string]{}
+	c := &Cache[string, string]{
+		stopped: true,
+	}
 	c.options.ttl = ttl
 	c.options.itemOpts = append(c.options.itemOpts,
 		withVersionTracking[string, string](false))
@@ -1341,7 +1370,7 @@ func prepCache(maxCost uint64, ttl time.Duration, keys ...string) *Cache[string,
 	if maxCost != 0 {
 		c.options.maxCost = maxCost
 		c.options.itemOpts = append(c.options.itemOpts,
-			withCostFunc[string, string](func(item *Item[string, string]) uint64 {
+			withCostFunc(func(item *Item[string, string]) uint64 {
 				return uint64(len(item.value))
 			}))
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1032,6 +1032,7 @@ func Test_Cache_Start(t *testing.T) {
 
 	cache.events.eviction.fns = make(map[uint64]func(EvictionReason, *Item[string, string]))
 	cache.stopCh = make(chan struct{})
+	cache.stopped = true
 
 	go cache.Start()
 	go cache.Start() // should be no-op
@@ -1041,6 +1042,8 @@ func Test_Cache_Start(t *testing.T) {
 		defer cache.stopMu.Unlock()
 		return !cache.stopped
 	}, time.Second, time.Millisecond*100)
+
+	assert.NotPanics(t, cache.Stop)
 
 }
 


### PR DESCRIPTION
Added a new flag to support calling stopped cache cleanup procedures as well as a mutex to control it. Now:
1. `Start` method will only run once even with the subsequent calls to it.
2. `Stop` will never block, in case the `Start` was not called or `Stop` was called before, it will return as the cache cleanup process is not running.

Closes #175 