### PR TITLE
Add OnUpdate method and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ func main() {
 }
 ```
 
-To subscribe to insertion and eviction events, `cache.OnInsertion()` and 
+To subscribe to insertion, update and eviction events, `cache.OnInsertion()`, `cache.OnUpdate()` and 
 `cache.OnEviction()` methods should be used:
 ```go
 func main() {
@@ -110,6 +110,9 @@ func main() {
 	)
 
 	cache.OnInsertion(func(ctx context.Context, item *ttlcache.Item[string, string]) {
+		fmt.Println(item.Value(), item.ExpiresAt())
+	})
+	cache.OnUpdate(func(ctx context.Context, item *ttlcache.Item[string, string]) {
 		fmt.Println(item.Value(), item.ExpiresAt())
 	})
 	cache.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, string]) {

--- a/cache.go
+++ b/cache.go
@@ -48,6 +48,11 @@ type Cache[K comparable, V any] struct {
 			nextID uint64
 			fns    map[uint64]func(*Item[K, V])
 		}
+		update struct {
+			mu     sync.RWMutex
+			nextID uint64
+			fns    map[uint64]func(*Item[K, V])
+		}
 		eviction struct {
 			mu     sync.RWMutex
 			nextID uint64
@@ -73,6 +78,7 @@ func New[K comparable, V any](opts ...Option[K, V]) *Cache[K, V] {
 	c.items.expQueue = newExpirationQueue[K, V]()
 	c.items.timerCh = make(chan time.Duration, 1) // buffer is important
 	c.events.insertion.fns = make(map[uint64]func(*Item[K, V]))
+	c.events.update.fns = make(map[uint64]func(*Item[K, V]))
 	c.events.eviction.fns = make(map[uint64]func(EvictionReason, *Item[K, V]))
 
 	c.options = applyOptions(c.options, opts...)
@@ -156,6 +162,16 @@ func (c *Cache[K, V]) set(key K, value V, ttl time.Duration) *Item[K, V] {
 				c.evict(EvictionReasonMaxCostExceeded, c.items.lru.Back())
 			}
 		}
+
+		c.metricsMu.Lock()
+		c.metrics.Updates++
+		c.metricsMu.Unlock()
+
+		c.events.update.mu.RLock()
+		for _, fn := range c.events.update.fns {
+			fn(item)
+		}
+		c.events.update.mu.RUnlock()
 
 		return item
 	}
@@ -732,6 +748,44 @@ func (c *Cache[K, V]) OnInsertion(fn func(context.Context, *Item[K, V])) func() 
 		c.events.insertion.mu.Lock()
 		delete(c.events.insertion.fns, id)
 		c.events.insertion.mu.Unlock()
+
+		wg.Wait()
+	}
+}
+
+// OnUpdate adds the provided function to be executed when
+// an item is updated in the cache. The function is executed
+// on a separate goroutine and does not block the flow of the cache
+// manager.
+// The returned function may be called to delete the subscription function
+// from the list of update subscribers.
+// When the returned function is called, it blocks until all instances of
+// the same subscription function return. A context is used to notify the
+// subscription function when the returned/deletion function is called.
+func (c *Cache[K, V]) OnUpdate(fn func(context.Context, *Item[K, V])) func() {
+	var (
+		wg          sync.WaitGroup
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+
+	c.events.update.mu.Lock()
+	id := c.events.update.nextID
+	c.events.update.fns[id] = func(item *Item[K, V]) {
+		wg.Add(1)
+		go func() {
+			fn(ctx, item)
+			wg.Done()
+		}()
+	}
+	c.events.update.nextID++
+	c.events.update.mu.Unlock()
+
+	return func() {
+		cancel()
+
+		c.events.update.mu.Lock()
+		delete(c.events.update.fns, id)
+		c.events.update.mu.Unlock()
 
 		wg.Wait()
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -30,6 +30,7 @@ func Test_New(t *testing.T) {
 	assert.NotNil(t, c.items.expQueue)
 	assert.NotNil(t, c.items.timerCh)
 	assert.NotNil(t, c.events.insertion.fns)
+	assert.NotNil(t, c.events.update.fns)
 	assert.NotNil(t, c.events.eviction.fns)
 	assert.Equal(t, time.Hour, c.options.ttl)
 	assert.Equal(t, uint64(1), c.options.capacity)
@@ -171,28 +172,45 @@ func Test_Cache_set(t *testing.T) {
 	const newKey, existingKey, evictedKey = "newKey123", "existingKey", "evicted"
 
 	cc := map[string]struct {
-		Capacity  uint64
-		MaxCost   uint64
-		Key       string
-		TTL       time.Duration
-		Metrics   Metrics
-		ExpectFns bool
+		Capacity     uint64
+		MaxCost      uint64
+		Key          string
+		TTL          time.Duration
+		Metrics      Metrics
+		InsertCalled bool
+		UpdateCalled bool
 	}{
 		"Set with existing key and custom TTL": {
 			Key: existingKey,
 			TTL: time.Minute,
+			Metrics: Metrics{
+				Updates: 1,
+			},
+			UpdateCalled: true,
 		},
 		"Set with existing key and NoTTL": {
 			Key: existingKey,
 			TTL: NoTTL,
+			Metrics: Metrics{
+				Updates: 1,
+			},
+			UpdateCalled: true,
 		},
 		"Set with existing key and DefaultTTL": {
 			Key: existingKey,
 			TTL: DefaultTTL,
+			Metrics: Metrics{
+				Updates: 1,
+			},
+			UpdateCalled: true,
 		},
 		"Set with existing key and PreviousOrDefaultTTL": {
 			Key: existingKey,
 			TTL: PreviousOrDefaultTTL,
+			Metrics: Metrics{
+				Updates: 1,
+			},
+			UpdateCalled: true,
 		},
 		"Set with new key and eviction caused by small capacity": {
 			Capacity: 3,
@@ -202,7 +220,7 @@ func Test_Cache_set(t *testing.T) {
 				Insertions: 1,
 				Evictions:  1,
 			},
-			ExpectFns: true,
+			InsertCalled: true,
 		},
 		"Set with new key and no eviction caused by large capacity": {
 			Capacity: 10,
@@ -211,7 +229,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Insertions: 1,
 			},
-			ExpectFns: true,
+			InsertCalled: true,
 		},
 		"Set with new key and custom TTL": {
 			Key: newKey,
@@ -219,7 +237,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Insertions: 1,
 			},
-			ExpectFns: true,
+			InsertCalled: true,
 		},
 		"Set with new key and NoTTL": {
 			Key: newKey,
@@ -227,7 +245,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Insertions: 1,
 			},
-			ExpectFns: true,
+			InsertCalled: true,
 		},
 		"Set with new key and DefaultTTL": {
 			Key: newKey,
@@ -235,7 +253,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Insertions: 1,
 			},
-			ExpectFns: true,
+			InsertCalled: true,
 		},
 		"Set with new key and PreviousOrDefaultTTL": {
 			Key: newKey,
@@ -243,7 +261,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Insertions: 1,
 			},
-			ExpectFns: true,
+			InsertCalled: true,
 		},
 		"Set with existing key and eviction caused by exhausted cost": {
 			MaxCost: 30,
@@ -251,8 +269,10 @@ func Test_Cache_set(t *testing.T) {
 			TTL:     DefaultTTL,
 			Metrics: Metrics{
 				Insertions: 0,
+				Updates:    1,
 				Evictions:  1,
 			},
+			UpdateCalled: true,
 		},
 		"Set with existing key and no eviction": {
 			MaxCost: 50,
@@ -260,8 +280,10 @@ func Test_Cache_set(t *testing.T) {
 			TTL:     DefaultTTL,
 			Metrics: Metrics{
 				Insertions: 0,
+				Updates:    1,
 				Evictions:  0,
 			},
+			UpdateCalled: true,
 		},
 		"Set with new key and eviction caused by exhausted cost": {
 			MaxCost: 40,
@@ -282,6 +304,7 @@ func Test_Cache_set(t *testing.T) {
 
 			var (
 				insertFnsCalls   int
+				updateFnsCalls   int
 				evictionFnsCalls int
 			)
 
@@ -295,7 +318,12 @@ func Test_Cache_set(t *testing.T) {
 				assert.Equal(t, newKey, item.key)
 				insertFnsCalls++
 			}
+			cache.events.update.fns[1] = func(item *Item[string, string]) {
+				assert.Equal(t, existingKey, item.key)
+				updateFnsCalls++
+			}
 			cache.events.insertion.fns[2] = cache.events.insertion.fns[1]
+			cache.events.update.fns[2] = cache.events.update.fns[1]
 			cache.events.eviction.fns[1] = func(r EvictionReason, item *Item[string, string]) {
 				if c.MaxCost != 0 {
 					assert.Equal(t, EvictionReasonMaxCostExceeded, r)
@@ -312,12 +340,16 @@ func Test_Cache_set(t *testing.T) {
 
 			item := cache.set(c.Key, "value123", c.TTL)
 
-			if c.ExpectFns {
+			if c.InsertCalled {
 				assert.Equal(t, 2, insertFnsCalls)
 
 				if c.Capacity > 0 && c.Capacity < 4 {
 					assert.Equal(t, 2, evictionFnsCalls)
 				}
+			}
+
+			if c.UpdateCalled {
+				assert.Equal(t, 2, updateFnsCalls)
 			}
 
 			assert.Same(t, cache.items.values[c.Key].Value.(*Item[string, string]), item)
@@ -1144,6 +1176,90 @@ func Test_Cache_OnInsertion(t *testing.T) {
 	assert.NotContains(t, cache.events.insertion.fns, uint64(1))
 }
 
+func Test_Cache_OnUpdate(t *testing.T) {
+	checkCh := make(chan struct{})
+	resCh := make(chan struct{})
+	cache := prepCache(0, time.Hour)
+	del1 := cache.OnUpdate(func(_ context.Context, _ *Item[string, string]) {
+		checkCh <- struct{}{}
+	})
+	del2 := cache.OnUpdate(func(_ context.Context, _ *Item[string, string]) {
+		checkCh <- struct{}{}
+	})
+
+	require.Len(t, cache.events.update.fns, 2)
+	assert.Equal(t, uint64(2), cache.events.update.nextID)
+
+	cache.events.update.fns[0](nil)
+
+	go func() {
+		del1()
+		resCh <- struct{}{}
+	}()
+	assert.Never(t, func() bool {
+		select {
+		case <-resCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Millisecond*200, time.Millisecond*100)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-checkCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Millisecond*500, time.Millisecond*250)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-resCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Millisecond*500, time.Millisecond*250)
+
+	require.Len(t, cache.events.update.fns, 1)
+	assert.NotContains(t, cache.events.update.fns, uint64(0))
+	assert.Contains(t, cache.events.update.fns, uint64(1))
+
+	cache.events.update.fns[1](nil)
+
+	go func() {
+		del2()
+		resCh <- struct{}{}
+	}()
+	assert.Never(t, func() bool {
+		select {
+		case <-resCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Millisecond*200, time.Millisecond*100)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-checkCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Millisecond*500, time.Millisecond*250)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-resCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Millisecond*500, time.Millisecond*250)
+
+	assert.Empty(t, cache.events.update.fns)
+	assert.NotContains(t, cache.events.update.fns, uint64(1))
+}
+
 func Test_Cache_OnEviction(t *testing.T) {
 	checkCh := make(chan struct{})
 	resCh := make(chan struct{})
@@ -1375,6 +1491,7 @@ func prepCache(maxCost uint64, ttl time.Duration, keys ...string) *Cache[string,
 	c.items.timerCh = make(chan time.Duration, 1)
 	c.events.eviction.fns = make(map[uint64]func(EvictionReason, *Item[string, string]))
 	c.events.insertion.fns = make(map[uint64]func(*Item[string, string]))
+	c.events.update.fns = make(map[uint64]func(*Item[string, string]))
 
 	addToCache(c, ttl, keys...)
 

--- a/metrics.go
+++ b/metrics.go
@@ -6,6 +6,9 @@ type Metrics struct {
 	// Insertions specifies how many items were inserted.
 	Insertions uint64
 
+	// Updates specifies how many items were updated.
+	Updates uint64
+
 	// Hits specifies how many items were successfully retrieved
 	// from the cache.
 	// Retrievals made with a loader function are not tracked.


### PR DESCRIPTION
Added a new method to track item updates as well as a metric to show how many times the items were updated.

Closes https://github.com/jellydator/ttlcache/issues/138