### PR TITLE
chore: expose cost of cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -637,6 +637,16 @@ func (c *Cache[K, V]) Metrics() Metrics {
 	return c.metrics
 }
 
+// Cost returns the total cost of all items currently stored in the cache.
+// Note: Cost tracking is only active when a maximum cost limit is configured.
+// If no maximum cost is set, this method will always return 0.
+func (c *Cache[K, V]) Cost() uint64 {
+	c.items.mu.RLock()
+	defer c.items.mu.RUnlock()
+
+	return c.cost
+}
+
 // Start starts an automatic cleanup process that periodically deletes
 // expired items.
 // It blocks until Stop is called.


### PR DESCRIPTION
issue:
- https://github.com/jellydator/ttlcache/issues/195

currently the cache keeps an internal field named `cost`

https://github.com/jellydator/ttlcache/blob/a21f6a646d2d08df066305d1bb1676295ff4194b/cache.go#L40

it might be nice to expose it so we don't need to calculate all cost of a cache through loop through all items
