### PR TITLE
test: avoid testing.AllocsPerRun panic with paused parallel tests

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -1538,15 +1539,27 @@ func addCacheItems(c *Cache[string, string], itemFn func(index int, key string) 
 }
 
 func allocsPerSingleRun(f func()) int {
-	// `testing.AllocsPerRun` "warms up" the function for a single run before
-	// measuring allocations, so we need to do nothing on the first run.
-	var firstRun bool
+	// Like testing.AllocsPerRun but safe to call while parallel tests are paused.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
 
-	return int(testing.AllocsPerRun(1, func() {
-		if !firstRun {
-			firstRun = true
-			return
-		}
-		f()
+	var memstats runtime.MemStats
+	runtime.ReadMemStats(&memstats)
+	mallocs := memstats.Mallocs
+
+	f()
+
+	runtime.ReadMemStats(&memstats)
+	return int(memstats.Mallocs - mallocs)
+}
+
+var allocSink *int
+
+func Test_allocsPerSingleRun_withPausedParallelTest(t *testing.T) {
+	t.Run("paused parallel sibling", func(t *testing.T) {
+		t.Parallel()
+	})
+
+	assert.Equal(t, 1, allocsPerSingleRun(func() {
+		allocSink = new(int)
 	}))
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1552,14 +1552,14 @@ func allocsPerSingleRun(f func()) int {
 	return int(memstats.Mallocs - mallocs)
 }
 
-var allocSink *int
-
 func Test_allocsPerSingleRun_withPausedParallelTest(t *testing.T) {
 	t.Run("paused parallel sibling", func(t *testing.T) {
 		t.Parallel()
 	})
 
+	var allocSink *int
 	assert.Equal(t, 1, allocsPerSingleRun(func() {
 		allocSink = new(int)
 	}))
+	runtime.KeepAlive(allocSink)
 }


### PR DESCRIPTION
Go 1.25 made `testing.AllocsPerRun` panic when invoked while any parallel test is paused, which makes the package's tests fail (`panic: testing: AllocsPerRun called during parallel test` from `Test_Cache_Get`). This replaces the `testing.AllocsPerRun` call in `allocsPerSingleRun` with an equivalent inline measurement that does not have that restriction.

Closes #207