### PR TITLE
fix: Range/RangeBackwards no longer skip items reordered mid-iteration

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -593,52 +593,63 @@ func (c *Cache[K, V]) Items() map[K]*Item[K, V] {
 	return items
 }
 
-// Range calls fn for each unexpired item in the cache. If fn returns false,
-// Range stops the iteration.
-func (c *Cache[K, V]) Range(fn func(item *Item[K, V]) bool) {
-	c.items.mu.RLock()
-
-	// Check if cache is empty
-	if c.items.lru.Len() == 0 {
-		c.items.mu.RUnlock()
-		return
+// snapshotKeysUnsafe returns the keys of all items currently in the LRU
+// list, in their current list order. Must be called while holding (at
+// least) a read lock on c.items.mu.
+func (c *Cache[K, V]) snapshotKeysUnsafe(front bool) []K {
+	keys := make([]K, 0, c.items.lru.Len())
+	next := func(e *list.Element) *list.Element { return e.Next() }
+	start := c.items.lru.Front
+	if !front {
+		next = func(e *list.Element) *list.Element { return e.Prev() }
+		start = c.items.lru.Back
 	}
+	for item := start(); item != nil; item = next(item) {
+		keys = append(keys, item.Value.(*Item[K, V]).key)
+	}
+	return keys
+}
 
-	for item := c.items.lru.Front(); c.items.lru.Len() != 0 && item != c.items.lru.Back().Next(); item = item.Next() {
-		i := item.Value.(*Item[K, V])
+// rangeKeys calls fn for each unexpired item whose key is in keys, skipping
+// keys that are no longer present (e.g. evicted, deleted, or replaced while
+// the iteration was paused). Iterating over a key snapshot, rather than the
+// live LRU list, means concurrent Set/Touch calls (which reorder the list
+// via MoveToFront) cannot cause items to be skipped or visited twice.
+func (c *Cache[K, V]) rangeKeys(keys []K, fn func(item *Item[K, V]) bool) {
+	for _, key := range keys {
+		c.items.mu.RLock()
+		elem, ok := c.items.values[key]
+		if !ok {
+			c.items.mu.RUnlock()
+			continue
+		}
+		i := elem.Value.(*Item[K, V])
 		expired := i.isExpiredUnsafe()
 		c.items.mu.RUnlock() // unlock mutex so fn func can access it (if it needs to)
 		if !expired && !fn(i) {
 			return
 		}
-		c.items.mu.RLock()
 	}
+}
 
+// Range calls fn for each unexpired item in the cache. If fn returns false,
+// Range stops the iteration.
+func (c *Cache[K, V]) Range(fn func(item *Item[K, V]) bool) {
+	c.items.mu.RLock()
+	keys := c.snapshotKeysUnsafe(true)
 	c.items.mu.RUnlock()
+
+	c.rangeKeys(keys, fn)
 }
 
 // RangeBackwards calls fn for each unexpired item in the cache in reverse order.
 // If fn returns false, RangeBackwards stops the iteration.
 func (c *Cache[K, V]) RangeBackwards(fn func(item *Item[K, V]) bool) {
 	c.items.mu.RLock()
-
-	// Check if cache is empty
-	if c.items.lru.Len() == 0 {
-		c.items.mu.RUnlock()
-		return
-	}
-
-	for item := c.items.lru.Back(); c.items.lru.Len() != 0 && item != c.items.lru.Front().Prev(); item = item.Prev() {
-		i := item.Value.(*Item[K, V])
-		expired := i.isExpiredUnsafe()
-		c.items.mu.RUnlock() // unlock mutex so fn func can access it (if it needs to)
-		if !expired && !fn(i) {
-			return
-		}
-		c.items.mu.RLock()
-	}
-
+	keys := c.snapshotKeysUnsafe(false)
 	c.items.mu.RUnlock()
+
+	c.rangeKeys(keys, fn)
 }
 
 // Metrics returns the metrics of the cache.

--- a/cache_test.go
+++ b/cache_test.go
@@ -1043,6 +1043,29 @@ func Test_Cache_Range(t *testing.T) {
 	})
 }
 
+// Test_Cache_Range_VisitsItemsReorderedDuringIteration is a regression test
+// for #205: calling Set/Touch on an item from within the Range callback
+// moves that item to the front of the LRU list. Range must still visit it
+// exactly once, even though its position relative to the iterator changed.
+func Test_Cache_Range_VisitsItemsReorderedDuringIteration(t *testing.T) {
+	c := New[string, int](WithTTL[string, int](time.Hour))
+	c.Set("key1", 1, DefaultTTL)
+	c.Set("key2", 2, DefaultTTL)
+	c.Set("key3", 3, DefaultTTL)
+	c.Set("key4", 4, DefaultTTL)
+
+	var visited []string
+	c.Range(func(item *Item[string, int]) bool {
+		visited = append(visited, item.Key())
+		if item.Value() == 4 {
+			c.Set("key3", 3, DefaultTTL)
+		}
+		return true
+	})
+
+	assert.ElementsMatch(t, []string{"key1", "key2", "key3", "key4"}, visited)
+}
+
 func Test_Cache_RangeBackwards(t *testing.T) {
 	c := prepCache(0, DefaultTTL)
 	addExpiredCacheItems(c, "1")


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change and ran the test suite before submitting.

## Problem

As described in #205, `Range`/`RangeBackwards` walk the live LRU list while releasing the read lock between steps. A concurrent `Set`/`Touch` call in that window can call `MoveToFront`, moving an item the iterator hasn't visited yet ahead of the current position, so it gets skipped entirely.

## Approach

@swithek noted in the issue thread that fully cloning the cache to avoid this would double its memory footprint, and @d1lmr0d suggested snapshotting keys instead. This PR takes that approach: instead of walking the live list, it takes a snapshot of keys (in current iteration order) up front under the read lock, then looks each key up again as it goes, skipping any that have since been evicted/deleted. This is the same number of lock acquisitions as before, but the iteration order is now fixed by the key snapshot rather than by list links that can move underneath it, so a concurrent reorder can no longer cause skips. The extra cost is one `[]K` slice (just keys, not full items), not a clone of the cache.

I'm not certain this is the direction you'd want to take it, given the issue is still open with no agreed approach. Happy to adjust if you'd prefer something else (e.g. documenting the existing semantics instead of changing them, or a different consistency guarantee).

## Changes

- `cache.go`: extracted `snapshotKeysUnsafe` (collects keys in list order under the read lock) and `rangeKeys` (re-looks-up each key, skips ones no longer present, calls `fn` outside the lock); `Range` and `RangeBackwards` now use these instead of walking the live list directly.
- `cache_test.go`: added `Test_Cache_Range_VisitsItemsReorderedDuringIteration`, reproducing the exact repro from #205 (`Set` on an unvisited key from within the `Range` callback). Verified it fails against the current code and passes with this fix.

## Testing

`go test ./...` passes (a few timer-based tests — `Test_Cache_Get`, `Test_Cache_OnInsertion`, `Test_Cache_OnUpdate` — are pre-existing flakes unrelated to this change; confirmed by running the full suite against unmodified `v3` as well). Could not run with `-race` in my sandbox (only a 32-bit MinGW gcc is available, which can't build cgo's race detector), but the bug itself is deterministic single-threaded reentrancy (calling `Set` from within the `Range` callback), not a true data race, so the new test exercises it directly without needing `-race`.

Fixes #205