### PR TITLE
Expose total cache cost via Cost()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -649,6 +649,16 @@ func (c *Cache[K, V]) Metrics() Metrics {
 	return c.metrics
 }
 
+// Cost returns the total cost of all items currently stored in the cache.
+// Note: Cost tracking is only active when a maximum cost limit is configured.
+// If no maximum cost is set, this method will always return 0.
+func (c *Cache[K, V]) Cost() uint64 {
+	c.items.mu.RLock()
+	defer c.items.mu.RUnlock()
+
+	return c.cost
+}
+
 // Start starts an automatic cleanup process that periodically deletes
 // expired items.
 // It blocks until Stop is called.

--- a/cache_test.go
+++ b/cache_test.go
@@ -1091,6 +1091,14 @@ func Test_Cache_Metrics(t *testing.T) {
 	assert.Equal(t, Metrics{Evictions: 10}, cache.Metrics())
 }
 
+func Test_Cache_Cost(t *testing.T) {
+	cache := Cache[string, string]{
+		cost: 10,
+	}
+
+	assert.Equal(t, uint64(10), cache.Cost())
+}
+
 func Test_Cache_Start(t *testing.T) {
 	cache := prepCache(0, 0)
 	cache.stopCh = make(chan struct{})


### PR DESCRIPTION
Resolves #195.

Identical to #196 , with the addition of a basic test since that PR appears to be unmaintained.