### PR TITLE
Add a IsStarted method to report whether the Start goroutine has actually started

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -659,12 +659,12 @@ func (c *Cache[K, V]) Cost() uint64 {
 	return c.cost
 }
 
-// Running returns true if the Start method has started and Stop has not called.
+// IsStarted returns true if the Start method has started and Stop has not called.
 // This is useful so that a caller doing `go c.Start` can ensure that the new
 // goroutine has actually started running.  Unless the caller waits to see that the
 // goroutine is running, a subsequent call to `Stop` might occur before
 // the goroutine gets scheduled, preventing proper shutdown of the goroutine.
-func (c *Cache[K, V]) Running() bool {
+func (c *Cache[K, V]) IsStarted() bool {
 	c.stopMu.Lock()
 	defer c.stopMu.Unlock()
 	return !c.stopped

--- a/cache.go
+++ b/cache.go
@@ -659,9 +659,9 @@ func (c *Cache[K, V]) Cost() uint64 {
 	return c.cost
 }
 
-// Running returns true if the Start method has started.  This is useful
-// so that a caller doing `go c.Start` can ensure that the new goroutine
-// has actually started running.  Unless the caller waits to see that the
+// Running returns true if the Start method has started and Stop has not called.
+// This is useful so that a caller doing `go c.Start` can ensure that the new
+// goroutine has actually started running.  Unless the caller waits to see that the
 // goroutine is running, a subsequent call to `Stop` might occur before
 // the goroutine gets scheduled, preventing proper shutdown of the goroutine.
 func (c *Cache[K, V]) Running() bool {

--- a/cache.go
+++ b/cache.go
@@ -659,6 +659,11 @@ func (c *Cache[K, V]) Cost() uint64 {
 	return c.cost
 }
 
+// Running returns true if the Start method has started.  This is useful
+// so that a caller doing `go c.Start` can ensure that the new goroutine
+// has actually started running.  Unless the caller waits to see that the
+// goroutine is running, a subsequent call to `Stop` might occur before
+// the goroutine gets scheduled, preventing proper shutdown of the goroutine.
 func (c *Cache[K, V]) Running() bool {
 	c.stopMu.Lock()
 	defer c.stopMu.Unlock()

--- a/cache.go
+++ b/cache.go
@@ -659,6 +659,12 @@ func (c *Cache[K, V]) Cost() uint64 {
 	return c.cost
 }
 
+func (c *Cache[K, V]) Running() bool {
+	c.stopMu.Lock()
+	defer c.stopMu.Unlock()
+	return !c.stopped
+}
+
 // Start starts an automatic cleanup process that periodically deletes
 // expired items.
 // It blocks until Stop is called.

--- a/cache_test.go
+++ b/cache_test.go
@@ -1170,13 +1170,13 @@ func Test_Cache_Running(t *testing.T) {
 	cache := New[string, string](
 		WithTTL[string, string](time.Hour))
 
-	assert.False(t, cache.Running())
+	assert.False(t, cache.IsStarted())
 
 	go cache.Start()
-	assert.Eventually(t, cache.Running, time.Second, time.Millisecond*100)
+	assert.Eventually(t, cache.IsStarted, time.Second, time.Millisecond*100)
 
 	cache.Stop()
-	assert.False(t, cache.Running())
+	assert.False(t, cache.IsStarted())
 }
 
 func Test_Cache_OnInsertion(t *testing.T) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -315,7 +315,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Updates: 1,
 			},
-			UpdateCalled: true,
+			UpdateCalled:              true,
 			ExpectedTimerNotification: time.Minute,
 		},
 		"Set with new key and shortened TTL": {
@@ -324,7 +324,7 @@ func Test_Cache_set(t *testing.T) {
 			Metrics: Metrics{
 				Insertions: 1,
 			},
-			InsertCalled: true,
+			InsertCalled:              true,
 			ExpectedTimerNotification: time.Minute,
 		},
 	}
@@ -1164,6 +1164,19 @@ func Test_Cache_Stop(t *testing.T) {
 	cache.stopped = false
 	cache.Stop()
 	assert.Len(t, cache.stopCh, 1)
+}
+
+func Test_Cache_Running(t *testing.T) {
+	cache := New[string, string](
+		WithTTL[string, string](time.Hour))
+
+	assert.False(t, cache.Running())
+
+	go cache.Start()
+	assert.Eventually(t, cache.Running, time.Second, time.Millisecond*100)
+
+	cache.Stop()
+	assert.False(t, cache.Running())
 }
 
 func Test_Cache_OnInsertion(t *testing.T) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -1166,7 +1166,7 @@ func Test_Cache_Stop(t *testing.T) {
 	assert.Len(t, cache.stopCh, 1)
 }
 
-func Test_Cache_Running(t *testing.T) {
+func Test_Cache_IsStarted(t *testing.T) {
 	cache := New[string, string](
 		WithTTL[string, string](time.Hour))
 


### PR DESCRIPTION
Fixes #203.  I'm writing tests using synctest and I need to be able to ensure that Stop never gets called before Start on a highly loaded system to prevent synctest panics due to goroutine leaks.